### PR TITLE
feat(mediator): add typed command/query pipelines and Send metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to **BuildingBlocks** packages in this repository are docume
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## BuildingBlocks.Mediator [1.1.0] - 2026-08-27
+
+### Added
+
+- `ICommandPipelineBehavior<,>` / `IQueryPipelineBehavior<,>` — compile-time command vs query pipelines (MS.DI does not construct the opposite kind)
+- `AddOpenCommandBehavior` / `AddOpenQueryBehavior` — fail fast when the type is not constrained
+- Opt-in Send metrics on `UseTelemetry()`: histogram `mediator.send.duration` (ms), counter `mediator.send` (tags `mediator.success`, `mediator.message_kind`, `mediator.request_name`); `EnableMetrics` (default true), `MeterName` (defaults to `ActivitySourceName`)
+
+### Changed
+
+- NuGet README rewritten for usage (quick start, typed behaviors, telemetry)
+- 1.0.1 `CommandPipelineBehavior` / `QueryPipelineBehavior` unchanged (not obsolete)
+
+### Notes
+
+- Drop-in upgrade from 1.0.1. No Publish / `INotification`. Host OpenTelemetry must `AddMeter("BuildingBlocks.Mediator")` (BuildingBlocks.Telemetry `IntegrateMediator` does this from 1.0.1).
+
+## BuildingBlocks.Telemetry [1.0.1] - 2026-08-27
+
+### Added
+
+- `TelemetryDefaults.MediatorMeter` (same name as `MediatorActivitySource`)
+- `IntegrateMediator` also `AddMeter` so mediator Send metrics export with traces
+
 ## BuildingBlocks.Telemetry [1.0.0] - 2026-08-25
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,44 @@
 # Contributing
 
-Thanks for contributing to **BuildingBlocks.Mediator**.
+Thanks for contributing to **FeatureFusion** — a .NET lab of production **BuildingBlocks** packages plus a runnable showcase.
+
+Formerly published as `Maxofpower/FeatureManagement`; GitHub redirects the old URL.
 
 ## Development
 
-1. Clone [FeatureManagement](https://github.com/Maxofpower/FeatureManagement).
-2. `dotnet test tests/BuildingBlocks.Mediator.Tests`
-3. `dotnet pack src/BuildingBlocks.Mediator -c Release -o artifacts/nuget`
+1. Clone [FeatureFusion](https://github.com/Maxofpower/FeatureFusion).
+2. `dotnet restore FeatureFusion.sln`
+3. Package tests (multi-TFM where applicable):
+   - `dotnet test tests/BuildingBlocks/Mediator.Tests`
+   - `dotnet test tests/BuildingBlocks/Mediator.Analyzers.Tests`
+   - `dotnet test tests/BuildingBlocks/Telemetry.Tests`
+   - `dotnet test tests/BuildingBlocks/Aspire.Hosting.SigNoz.Tests`
+4. Pack: `dotnet pack src/BuildingBlocks/Mediator -c Release -o artifacts/nuget`
 
 ## Guidelines
 
+### BuildingBlocks.Mediator
+
 - Keep the public surface CQRS-first (`ICommand` / `IQuery`); no Publish in v1.
+- Prefer `ICommandPipelineBehavior` / `IQueryPipelineBehavior` for new command/query-only open generics.
 - Do not add Scrutor, FluentValidation, or other mediator/messaging packages as dependencies of the core library.
 - Add/adjust tests for supported and explicitly unsupported behaviors ([TEST_MATRIX.md](docs/building-blocks/TEST_MATRIX.md)).
 - Public API changes: update `PublicAPI.Unshipped.txt` / XML docs.
-- Contributions are accepted under the project **MIT** license (inbound = outbound).
+
+### BuildingBlocks.Telemetry / SigNoz hosting
+
+- Keep OpenTelemetry packages on stable versions (no prerelease deps).
+- Do not log endpoints, OTLP headers, or connection strings.
+
+### Lab (FeatureFusion)
+
+- Prefer vertical-slice feature folders under `Features/{Name}/`.
+- Leave `Microsoft.FeatureManagement` and `FeatureManagement` JSON as the original feature-flag demo — not the product identity.
+
+Contributions are accepted under the project **MIT** license (inbound = outbound).
 
 ## Pull requests
 
 - Prefer focused PRs with tests.
-- Run the Mediator test project green before requesting review.
+- Run the relevant test project(s) green before requesting review.
+- When you publish a LinkedIn post tied to this repo, add a row in [docs/linkedin-posts.md](docs/linkedin-posts.md).

--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 
 # FeatureFusion
 
-**Advanced .NET lab** — real patterns from LinkedIn deep-dives, runnable locally with Aspire.
+**BuildingBlocks for .NET** — CQRS Send + pipeline, config-driven OpenTelemetry, and a local Aspire SigNoz stack — plus a runnable lab that uses them.
 
-[![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)](https://dotnet.microsoft.com/)
+Formerly [FeatureManagement](https://github.com/Maxofpower/FeatureManagement) (GitHub redirects).
+
+[![.NET](https://img.shields.io/badge/.NET-8%20%7C%209%20%7C%2010-512BD4?logo=dotnet&logoColor=white)](https://dotnet.microsoft.com/)
 [![Aspire](https://img.shields.io/badge/Aspire-13.4-C3002F?logo=dotnet&logoColor=white)](https://learn.microsoft.com/dotnet/aspire/)
-[![NuGet · BuildingBlocks.Mediator](https://img.shields.io/nuget/v/BuildingBlocks.Mediator.svg?label=NuGet%20·%20BuildingBlocks.Mediator&logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Mediator)
+[![NuGet · BuildingBlocks.Mediator](https://img.shields.io/nuget/v/BuildingBlocks.Mediator.svg?label=NuGet%20·%20Mediator&logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Mediator)
 [![NuGet · BuildingBlocks.Telemetry](https://img.shields.io/nuget/v/BuildingBlocks.Telemetry.svg?label=NuGet%20·%20Telemetry&logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Telemetry)
 [![NuGet · BuildingBlocks.Aspire.Hosting.SigNoz](https://img.shields.io/nuget/v/BuildingBlocks.Aspire.Hosting.SigNoz.svg?label=NuGet%20·%20SigNoz%20hosting&logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Aspire.Hosting.SigNoz)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
-[![Stars](https://img.shields.io/github/stars/Maxofpower/FeatureManagement?style=social)](https://github.com/Maxofpower/FeatureManagement/stargazers)
-[![Last commit](https://img.shields.io/github/last-commit/Maxofpower/FeatureManagement)](https://github.com/Maxofpower/FeatureManagement/commits)
+[![Stars](https://img.shields.io/github/stars/Maxofpower/FeatureFusion?style=social)](https://github.com/Maxofpower/FeatureFusion/stargazers)
+[![Last commit](https://img.shields.io/github/last-commit/Maxofpower/FeatureFusion)](https://github.com/Maxofpower/FeatureFusion/commits)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-mhhoseini-0A66C2?logo=linkedin&logoColor=white)](https://www.linkedin.com/in/mhhoseini/)
-[![Repo](https://img.shields.io/badge/GitHub-FeatureManagement-181717?logo=github)](https://github.com/Maxofpower/FeatureManagement)
+[![Repo](https://img.shields.io/badge/GitHub-FeatureFusion-181717?logo=github)](https://github.com/Maxofpower/FeatureFusion)
 
 [Author · Mohammad Hasan Hosseini](https://www.linkedin.com/in/mhhoseini/) · Technical Team Lead & .NET enthusiast
 
@@ -23,13 +25,18 @@
 
 ## Table of contents
 
-- [What's inside](#whats-inside)
+- [BuildingBlocks](#buildingblocks)
+  - [How they work together](#how-they-work-together)
+  - [BuildingBlocks.Mediator](#buildingblocksmediator)
+  - [BuildingBlocks.Telemetry](#buildingblockstelemetry)
+  - [BuildingBlocks.Aspire.Hosting.SigNoz](#buildingblocksaspirehostingsignoz)
+- [Lab](#lab)
 - [Architecture](#architecture)
 - [Stack](#stack)
 - [Repository layout](#repository-layout)
 - [Prerequisites](#prerequisites)
-- [Quick start](#quick-start)
-- [Features](#features)
+- [Run the lab](#run-the-lab)
+- [Lab features](#lab-features)
 - [Design patterns](#design-patterns)
 - [LinkedIn catalog](#linkedin-catalog)
 - [What's next](#whats-next)
@@ -38,25 +45,203 @@
 
 ---
 
-## What's inside
+## BuildingBlocks
+
+Three NuGet packages you can install in **your** hosts. The FeatureFusion API is a showcase, not a required dependency.
+
+| Package | Role | TFMs |
+|---------|------|------|
+| **[BuildingBlocks.Mediator](https://www.nuget.org/packages/BuildingBlocks.Mediator)** | CQRS **Send** + ordered pipeline (`ICommand` / `IQuery`, typed behaviors, opt-in traces + metrics) | net8 / net9 / net10 |
+| **[BuildingBlocks.Telemetry](https://www.nuget.org/packages/BuildingBlocks.Telemetry)** | Config-driven OpenTelemetry (traces, metrics, logs) + `IntegrateMediator` | net8 / net9 / net10 |
+| **[BuildingBlocks.Aspire.Hosting.SigNoz](https://www.nuget.org/packages/BuildingBlocks.Aspire.Hosting.SigNoz)** | Local-dev Aspire `AddSigNoz()` + `WithSigNozOtlpExporter` | net10 (AppHost) |
+
+Production apps use **Mediator + Telemetry** and export OTLP to any backend. SigNoz hosting is **local AppHost only**.
+
+### How they work together
+
+```mermaid
+flowchart LR
+  host[Your host]
+  med[Mediator]
+  tel[Telemetry]
+  otlp[OTLP backend]
+  signoz[SigNoz AppHost]
+  host --> med
+  med -->|"UseTelemetry"| tel
+  tel -->|"AddTelemetry IntegrateMediator"| otlp
+  signoz -->|"local collector"| otlp
+```
+
+1. **Mediator** dispatches commands/queries through an ordered pipeline. `UseTelemetry()` wraps **Send** (not a pipeline behavior) with an ActivitySource and Meter named `BuildingBlocks.Mediator`.
+2. **Telemetry** `AddTelemetry` + `IntegrateMediator = true` registers that source **and** meter so spans and `mediator.send` metrics export with the rest of the host.
+3. **SigNoz hosting** (optional, local) provisions a collector + UI. `WithSigNozOtlpExporter` sets `OTEL_EXPORTER_OTLP_*` on a **project** resource. In production, set the same env vars to your collector.
+
+**Compose** (same shape as this lab):
+
+```csharp
+// API / worker — BuildingBlocks.Telemetry + BuildingBlocks.Mediator
+builder.AddTelemetry(o =>
+{
+    o.IntegrateMediator = true;
+    o.Instrumentation.Npgsql = true;
+});
+
+builder.Services.AddMediator(cfg =>
+{
+    cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+    cfg.AddOpenBehavior(typeof(ValidationBehavior<,>), order: 0); // host-owned
+    cfg.UseTelemetry();
+    cfg.ValidateOnStartup = true;
+});
+
+// AppHost — BuildingBlocks.Aspire.Hosting.SigNoz (local)
+var signoz = builder.AddSigNoz("signoz")
+    .WithUi()
+    .WithDashboards();
+
+builder.AddProject<Projects.Api>("api")
+    .WithSigNozOtlpExporter(signoz);
+```
+
+---
+
+### BuildingBlocks.Mediator
+
+[![NuGet](https://img.shields.io/nuget/v/BuildingBlocks.Mediator.svg?logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Mediator)
+[![Downloads](https://img.shields.io/nuget/dt/BuildingBlocks.Mediator.svg)](https://www.nuget.org/packages/BuildingBlocks.Mediator)
+
+CQRS-first **Send** + ordered **pipeline**. Manual control over registration, pipeline order, validation, and telemetry — not a MediatR or messaging replacement (no `Publish` / `INotification` in v1).
+
+**What's new in 1.1.0:** typed `ICommandPipelineBehavior` / `IQueryPipelineBehavior` (MS.DI does not construct the opposite kind), `AddOpenCommandBehavior` / `AddOpenQueryBehavior`, opt-in Send metrics. Drop-in from 1.0.1.
+
+```bash
+dotnet add package BuildingBlocks.Mediator
+```
+
+```csharp
+public sealed record CreateOrder(string Product, int Qty) : ICommand<Guid>;
+
+public sealed class CreateOrderHandler : ICommandHandler<CreateOrder, Guid>
+{
+    public Task<Guid> Handle(CreateOrder command, CancellationToken ct)
+        => Task.FromResult(Guid.NewGuid());
+}
+
+// Send — prefer ISender at call sites
+await sender.Send(new CreateOrder("SKU-1", 2), ct);
+```
+
+| Capability | What it does |
+|------------|--------------|
+| `ICommand` / `ICommand<T>` / `IQuery<T>` | CQRS contracts; void writes via `ICommand : ICommand<Unit>` |
+| Ordered pipeline | Open/closed behaviors; `order` lower = outermost |
+| `AddOpenCommandBehavior` / `AddOpenQueryBehavior` | Command- or query-only types are not constructed for the other kind |
+| `UseTelemetry()` | Optional ActivitySource + Meter around the whole Send |
+| `ValidateOnStartup` | Fails fast on missing or duplicate handlers |
+| Open-generic handlers | Closed on demand; built-in scanner (no Scrutor) |
+| Analyzers BBM001 / BBM002 | Packed in the NuGet |
+
+- Package README: [`src/BuildingBlocks/Mediator/PACKAGE_README.md`](src/BuildingBlocks/Mediator/PACKAGE_README.md)
+- Docs: [getting-started](docs/building-blocks/getting-started.md) · [pipeline](docs/building-blocks/pipeline-behaviors.md) · [cookbook](docs/building-blocks/cookbook.md) · [test matrix](docs/building-blocks/TEST_MATRIX.md)
+- Freeze / ADR: [`docs/building-blocks/mediator.md`](docs/building-blocks/mediator.md) · [`docs/adr/0001-mediator-building-blocks-in-monorepo.md`](docs/adr/0001-mediator-building-blocks-in-monorepo.md)
+- [Mediator Pattern + Pipeline Behavior](https://www.linkedin.com/feed/update/urn:li:activity:7311311587372367873/) (prior post; building-blocks revision planned)
+
+---
+
+### BuildingBlocks.Telemetry
+
+[![NuGet](https://img.shields.io/nuget/v/BuildingBlocks.Telemetry.svg?logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Telemetry)
+[![GitHub Release](https://img.shields.io/github/v/release/Maxofpower/FeatureFusion?filter=telemetry-v*&logo=github&label=GitHub%20Release)](https://github.com/Maxofpower/FeatureFusion/releases/tag/telemetry-v1.0.0)
+
+Config-driven OpenTelemetry for ASP.NET Core: traces, metrics, and logs from one `AddTelemetry` call. Export **OTLP to any backend**. Requires `IHostApplicationBuilder`.
+
+**What's new in 1.0.1:** `IntegrateMediator` also `AddMeter("BuildingBlocks.Mediator")` so Send metrics export with traces (`TelemetryDefaults.MediatorMeter`).
+
+```bash
+dotnet add package BuildingBlocks.Telemetry
+```
+
+```csharp
+builder.AddTelemetry(o =>
+{
+    o.IntegrateMediator = true;
+    o.Instrumentation.Npgsql = true;
+    o.Instrumentation.EventBus = true;
+});
+```
+
+OTLP turns on when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Prefer env over hard-coded URLs.
+
+| Capability | What it does |
+|------------|--------------|
+| `AddTelemetry` | Traces + metrics + logs, resource `deployment.environment` |
+| ASP.NET / HttpClient / Runtime / Npgsql | On by default; SqlClient opt-in |
+| `IntegrateMediator` | ActivitySource **and** Meter for `BuildingBlocks.Mediator` |
+| `telemetry.component` | Span tag for filtering in the backend |
+| `TelemetryBuilder` | `ConfigureTracing` / `AddSource` / `AddMeter` for EF, Redis, extra meters |
+| Startup summary | One Information log of signals and instrumentation (never logs endpoints or secrets) |
+
+- Package README: [`src/BuildingBlocks/Telemetry/PACKAGE_README.md`](src/BuildingBlocks/Telemetry/PACKAGE_README.md)
+- Docs: [telemetry](docs/building-blocks/telemetry.md)
+
+---
+
+### BuildingBlocks.Aspire.Hosting.SigNoz
+
+[![NuGet](https://img.shields.io/nuget/v/BuildingBlocks.Aspire.Hosting.SigNoz.svg?logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Aspire.Hosting.SigNoz)
+[![GitHub Release](https://img.shields.io/github/v/release/Maxofpower/FeatureFusion?filter=signoz-v*&logo=github&label=GitHub%20Release)](https://github.com/Maxofpower/FeatureFusion/releases/tag/signoz-v1.0.0)
+
+Local-dev **Aspire AppHost** integration: ClickHouse, ZooKeeper, schema migrator, OTLP collector, and SigNoz UI. **Not for production** — production still uses `BuildingBlocks.Telemetry` against any OTLP endpoint. Docker required. TFM **net10.0** (Aspire 13.4.6).
+
+```bash
+dotnet add package BuildingBlocks.Aspire.Hosting.SigNoz
+```
+
+```csharp
+var signoz = builder.AddSigNoz("signoz")
+    .WithUi()
+    .WithDashboards();
+
+builder.AddProject<Projects.Api>("api")
+    .WithSigNozOtlpExporter(signoz);
+```
+
+Run the AppHost **https** profile. The UI waits until the migrator exits 0.
+
+| API | Role |
+|-----|------|
+| `AddSigNoz` | ZooKeeper, ClickHouse, migrator, collector, UI |
+| `WithUi` | Host port + local admin credentials (password policy applies) |
+| `WithDashboards` | Seeds ASP.NET Core + BuildingBlocks dashboards |
+| `WithDataVolume` / `WithDataBindMount` | Persist ClickHouse **and** ZooKeeper |
+| `WithSigNozOtlpExporter` | `OTEL_EXPORTER_OTLP_*` on a **`ProjectResource` only** |
+
+- Package README: [`src/BuildingBlocks/Aspire.Hosting.SigNoz/PACKAGE_README.md`](src/BuildingBlocks/Aspire.Hosting.SigNoz/PACKAGE_README.md)
+- Docs: [telemetry](docs/building-blocks/telemetry.md) · [alerts](deploy/signoz/alerts/README.md)
+
+---
+
+## Lab
+
+Install the packages above in your own hosts, **or** clone this repo and run **FeatureFusion** — a showcase API + AppHost that already wires Mediator, Telemetry, and SigNoz.
 
 | Area | What you get |
 |------|----------------|
-| Feature management | ASP.NET Core Feature Management + custom filters (claims / VIP demos) |
+| Mediator (CQRS) | **`BuildingBlocks.Mediator`** — used by FeatureFusion handlers |
+| Telemetry | **`BuildingBlocks.Telemetry`** in ServiceDefaults; **`BuildingBlocks.Aspire.Hosting.SigNoz`** on AppHost |
 | Event bus | RabbitMQ + transactional outbox/inbox, DLQ, dedup hooks |
-| Aspire | AppHost orchestration for Postgres, Redis, RabbitMQ, Memcached |
+| Aspire lab | AppHost orchestration for Postgres, Redis, RabbitMQ, Memcached, SigNoz |
 | IdempotentFusion | ULID `Idempotency-Key` + Redis status tracking + optional lock |
-| Mediator (CQRS) | **`BuildingBlocks.Mediator`** NuGet — CQRS Send + ordered pipeline, telemetry, startup validation |
-| Telemetry | **`BuildingBlocks.Telemetry`** — config-driven OTel metrics/logs/traces; **`BuildingBlocks.Aspire.Hosting.SigNoz`** — `AddSigNoz()` |
+| Feature flags (demo) | ASP.NET Core Feature Management + custom filters (claims / VIP) |
 | API surface | Versioned controllers + Minimal APIs, FluentValidation patterns |
 | Gateway | YARP reverse proxy + Memcached distributed rate limiting |
 | Caching | Redis / Memcached / memory managers + middleware demos |
-| Pagination | **Generic bidirectional keyset (cursor) pagination** — type-safe Base64 cursors, dynamic sort, expression trees |
+| Pagination | **Generic bidirectional keyset (cursor) pagination** |
 | Design patterns | Mediator, Decorator, CoR, Strategy, and more — see below |
 
-Also covered in the lab: app/DB initializers, middleware dynamic caching, Aspire AppHost integration tests, and performance-minded practices (OTel hooks, resilience).
+Also in the lab: app/DB initializers, middleware dynamic caching, Aspire AppHost integration tests, and performance-minded practices (OTel hooks, resilience).
 
-> Aspire-hosted functional tests and compose need **Docker**.
+> Aspire-hosted functional tests and Compose need **Docker**.
 
 ---
 
@@ -65,19 +250,21 @@ Also covered in the lab: app/DB initializers, middleware dynamic caching, Aspire
 ```mermaid
 flowchart LR
   Client([HTTP clients]) --> FF[FeatureFusion API]
-  Client --> GW[ApiGateway · YARP]
+  Client --> GW[ApiGateway]
   GW --> FF
-  subgraph Aspire AppHost
+  subgraph aspireHost [Aspire AppHost]
     FF
     PG[(Postgres)]
     RD[(Redis)]
     RMQ[[RabbitMQ]]
     MC[(Memcached)]
+    SZ[SigNoz]
   end
   FF --> PG
   FF --> RD
   FF --> RMQ
   FF --> MC
+  FF -->|"OTLP"| SZ
   GW --> MC
 ```
 
@@ -94,33 +281,43 @@ flowchart LR
 [![xUnit](https://img.shields.io/badge/tests-xUnit-512BD4)](https://xunit.net/)
 [![Docker](https://img.shields.io/badge/Docker-required-2496ED?logo=docker&logoColor=white)](https://www.docker.com/)
 
-**.NET 10** (`net10.0`) · **Aspire 13.4.x** · FluentValidation · Feature Management · Memcached (Enyim)
+**.NET 10** (`net10.0`) for the lab · packages also target **net8 / net9** where noted · **Aspire 13.4.x** · FluentValidation · Feature Management · Memcached (Enyim)
 
 ---
 
 ## Repository layout
 
 ```text
-src/
-  BuildingBlocks.Mediator/          # CQRS Send + pipeline NuGet building block
-  BuildingBlocks.Telemetry/         # Config-driven OpenTelemetry NuGet
-  BuildingBlocks.Aspire.Hosting.SigNoz/  # AddSigNoz() Aspire hosting NuGet
-  FeatureFusion/                    # Web API (Features/, Infrastructure/, Controllers, Minimal APIs)
-  EventBusRabbitMQ/                 # Reusable RabbitMQ event bus library
-  FeatureFusion.ApiGateway/         # YARP + Memcached rate limiter
-  FeatureFusion.AppHost.AppHost/    # Aspire AppHost (+ SigNoz stack)
-  FeatureFusion.AppHost.ServiceDefaults/
+FeatureFusion.sln                   # .NET only
+src/                                # C# only
+  BuildingBlocks/
+    Mediator/                       # CQRS Send + pipeline NuGet
+    Mediator.Analyzers/
+    Telemetry/                      # Config-driven OpenTelemetry NuGet
+    Aspire.Hosting.SigNoz/          # AddSigNoz() Aspire hosting NuGet
+  Lab/
+    FeatureFusion/                  # Web API showcase (Features/, Infrastructure/, Controllers, Minimal APIs)
+    FeatureFusion.ApiGateway/       # YARP + Memcached rate limiter
+    FeatureFusion.AppHost/          # Aspire AppHost (+ SigNoz stack)
+    FeatureFusion.ServiceDefaults/
+    EventBus/                       # Reusable RabbitMQ event bus (namespaces stay EventBusRabbitMQ)
+web/                                # reserved — Next.js project root (not created yet; not in the .sln)
 tests/
-  BuildingBlocks.Telemetry.Tests/
-  BuildingBlocks.Aspire.Hosting.SigNoz.Tests/
-  IntegrationTests/                 # Aspire fixture · EventBus + HTTP API smoke
-  FeatureFusion.Test/               # Unit / filter / mediator
-  FeatureFusion.ApiGateway.Test/
-  FeatureFusion.Common/
+  BuildingBlocks/
+    Mediator.Tests/
+    Mediator.Analyzers.Tests/
+    Telemetry.Tests/
+    Aspire.Hosting.SigNoz.Tests/
+  Lab/
+    IntegrationTests/               # Aspire fixture · EventBus + HTTP API smoke
+    FeatureFusion.Tests/            # Unit / filter / mediator
+    FeatureFusion.ApiGateway.Tests/
+    FeatureFusion.Common/
+benchmarks/BuildingBlocks/Mediator.Benchmarks/
 deploy/signoz/alerts/               # Repo-owned SigNoz alert samples (not packaged)
 docs/
   linkedin-posts.md                 # Post ↔ code map
-  building-blocks/telemetry.md
+  building-blocks/
 ```
 
 <details>
@@ -142,7 +339,7 @@ Features/{Name}/
 
 | Tool | Why |
 |------|-----|
-| [.NET 10 SDK](https://dotnet.microsoft.com/download) | Build & run |
+| [.NET 10 SDK](https://dotnet.microsoft.com/download) | Build & run the lab (package tests also use 8 / 9 SDKs in CI) |
 | [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Linux containers, running) | Aspire resources, Compose, functional tests |
 | Aspire dashboard (optional) | Resource graph when using AppHost |
 
@@ -150,15 +347,24 @@ If the Aspire dashboard shows **Container runtime not installed** while `docker 
 
 ---
 
-## Quick start
+## Run the lab
 
 ### Option A — Aspire AppHost (recommended)
 
 ```bash
-dotnet run --project src/FeatureFusion.AppHost.AppHost
+dotnet run --project src/Lab/FeatureFusion.AppHost
 ```
 
-Starts Postgres, Redis, RabbitMQ, Memcached, and `FeatureFusion`. Open the Aspire dashboard URL printed in the console.
+Starts Postgres, Redis, RabbitMQ, Memcached, SigNoz, and `FeatureFusion`. Open the Aspire dashboard URL printed in the console.
+
+The SigNoz UI always shows a **login** page. Root-user env vars skip the first-run **signup** wizard; they do not disable auth. This lab’s credentials come from `src/Lab/FeatureFusion.AppHost/appsettings.Development.json` via `WithUiFromConfiguration` (override with `SigNoz__AdminEmail` / `SigNoz__AdminPassword`):
+
+| | |
+|---|---|
+| Email | `dev@local.test` |
+| Password | `DevPassword123!` |
+
+Those custom credentials are **not** shown on the Aspire resource panel (only package-default `WithUi()` creds are). Package defaults, if you call `WithUi()` with no overrides, are `admin@localhost.local` / `Admin@Signoz1`. If login fails after changing email, delete the persistent SigNoz sqlite volume and restart AppHost.
 
 ### Option B — Docker Compose
 
@@ -171,8 +377,8 @@ Uses SDK / ASP.NET **10.0** images plus supporting services.
 ### Option C — API only
 
 ```bash
-dotnet restore FeatureManagementFilters.sln
-dotnet run --project src/FeatureFusion --launch-profile https
+dotnet restore FeatureFusion.sln
+dotnet run --project src/Lab/FeatureFusion --launch-profile https
 ```
 
 Point connection strings in `appsettings.*.json` (or user secrets) at your local infra.
@@ -187,13 +393,13 @@ Point connection strings in `appsettings.*.json` (or user secrets) at your local
 
 ---
 
-## Features
+## Lab features
 
 ### RabbitMQ EventBus (outbox / inbox / DLQ)
 
 Transactional outbox with optional direct publish fallback, inbox/dedup hooks, DLX, and Aspire-hosted integration tests.
 
-**Setup:** AppHost or Compose, then `dotnet test tests/IntegrationTests`.  
+**Setup:** AppHost or Compose, then `dotnet test tests/Lab/IntegrationTests`.  
 **LinkedIn:** see the [catalog](docs/linkedin-posts.md).
 
 ### Distributed rate limiting (YARP + Memcached)
@@ -216,159 +422,6 @@ REST idempotency with ULID keys and Redis status tracking (`POST /api/v2/Order/o
 - [Idempotency with CQRS](https://www.linkedin.com/feed/update/urn:li:activity:7303686809891356676/)
 - [IdempotentFusion project](https://www.linkedin.com/feed/update/urn:li:activity:7309149985307029504/)
 
-### BuildingBlocks.Mediator (CQRS Send + pipeline)
-
-[![NuGet](https://img.shields.io/nuget/v/BuildingBlocks.Mediator.svg?logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Mediator)
-[![Downloads](https://img.shields.io/nuget/dt/BuildingBlocks.Mediator.svg)](https://www.nuget.org/packages/BuildingBlocks.Mediator)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.txt)
-
-Extracted as the **`BuildingBlocks.Mediator`** NuGet package — CQRS-first `ICommand` / `IQuery`, Send + ordered pipeline, opt-in `UseTelemetry`, `ValidateOnStartup`, configurable `HandlerLifetime`, open-generic handler support, exact-one handler resolution, and a built-in scanner (no Scrutor). Metrics/validation via host `AddOpenBehavior`. Ships Roslyn analyzers (BBM001/BBM002). No Publish/notifications.
-
-> **Disclaimer:** Not designed to replace other mediator or messaging packages — for developers who want **manual control** over design patterns (registration, pipeline, validation, telemetry) rather than a batteries-included framework.
-
-#### How to use
-
-**1. Install** (requires **.NET 8+**):
-
-```bash
-dotnet add package BuildingBlocks.Mediator
-```
-
-**2. Define a command/query and its handler** — one handler per message:
-
-```csharp
-public sealed record CreateOrder(string Product, int Qty) : ICommand<Guid>;
-
-public sealed class CreateOrderHandler : ICommandHandler<CreateOrder, Guid>
-{
-    public Task<Guid> Handle(CreateOrder command, CancellationToken ct)
-        => Task.FromResult(Guid.NewGuid());
-}
-```
-
-**3. Register** — scan for handlers, add host behaviors, opt into telemetry/validation:
-
-```csharp
-builder.Services.AddMediator(cfg =>
-{
-    cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
-    cfg.AddOpenBehavior(typeof(ValidationBehavior<,>), order: 0); // lower = outermost
-    cfg.UseTelemetry();          // optional Send wrap (not a pipeline behavior)
-    cfg.ValidateOnStartup = true; // fail fast on missing/duplicate handlers
-});
-```
-
-**4. Send** — inject `ISender` (narrower than `IMediator`) and dispatch:
-
-```csharp
-public sealed class OrdersController(ISender sender) : ControllerBase
-{
-    [HttpPost]
-    public Task<Guid> Create(CreateOrder command, CancellationToken ct)
-        => sender.Send(command, ct);
-}
-```
-
-| Capability | What it does |
-|------------|--------------|
-| `ICommand` / `ICommand<T>` / `IQuery<T>` | CQRS message contracts; void commands via `ICommand : ICommand<Unit>` |
-| `AddOpenBehavior(type, order)` | Ordered pipeline behaviors (lower `order` = outermost) |
-| `UseTelemetry()` | Optional `ActivitySource` wrap around the whole Send (not a pipeline step) |
-| `ValidateOnStartup` | Fails fast when a message has zero or multiple handlers |
-| `HandlerLifetime` | Transient (default) / Scoped / Singleton for discovered handlers |
-| Open-generic handlers | Closed on demand (e.g. `Handler<T> : ICommandHandler<Cmd<T>, T>`) |
-| Analyzers BBM001 / BBM002 | Catch wrong handler kind and same-compilation missing handlers |
-
-- Package: [NuGet · BuildingBlocks.Mediator](https://www.nuget.org/packages/BuildingBlocks.Mediator)
-- Code: [`src/BuildingBlocks.Mediator`](src/BuildingBlocks.Mediator)
-- Docs: [getting-started](docs/building-blocks/getting-started.md) · [concepts](docs/building-blocks/concepts.md) · [pipeline-behaviors](docs/building-blocks/pipeline-behaviors.md) · [cookbook](docs/building-blocks/cookbook.md)
-- Freeze: [`docs/building-blocks/mediator.md`](docs/building-blocks/mediator.md)
-- ADR: [`docs/adr/0001-mediator-building-blocks-in-monorepo.md`](docs/adr/0001-mediator-building-blocks-in-monorepo.md)
-- [Mediator Pattern + Pipeline Behavior](https://www.linkedin.com/feed/update/urn:li:activity:7311311587372367873/) (prior post; building-blocks revision planned)
-
-### BuildingBlocks.Telemetry
-
-[![NuGet](https://img.shields.io/nuget/v/BuildingBlocks.Telemetry.svg?logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Telemetry)
-[![GitHub Release](https://img.shields.io/github/v/release/Maxofpower/FeatureManagement?filter=telemetry-v*&logo=github&label=GitHub%20Release)](https://github.com/Maxofpower/FeatureManagement/releases/tag/telemetry-v1.0.0)
-
-Config-driven OpenTelemetry for ASP.NET Core: traces, metrics, and logs from one `AddTelemetry` call. Production apps export **OTLP to any backend** (SigNoz, collector, cloud). Stable instrumentations (ASP.NET Core, HttpClient, Runtime, Npgsql; SqlClient opt-in), `telemetry.component` span tags, and a startup summary that never logs endpoints or secrets.
-
-Requires **.NET 8 / 9 / 10**.
-
-#### How to use
-
-**1. Install**
-
-```bash
-dotnet add package BuildingBlocks.Telemetry
-```
-
-**2. Register** — FeatureFusion uses this from ServiceDefaults; a host can call it directly:
-
-```csharp
-builder.AddTelemetry(o =>
-{
-    o.IntegrateMediator = true;
-    o.Instrumentation.Npgsql = true;
-    o.Instrumentation.EventBus = true;
-});
-```
-
-**3. Export** — set `OTEL_EXPORTER_OTLP_ENDPOINT` (Aspire `WithSigNozOtlpExporter` does this locally). Prefer env over hard-coded URLs. On that fast-path, `OTEL_EXPORTER_OTLP_PROTOCOL` wins over `Exporters.Otlp.Protocol`.
-
-| Capability | What it does |
-|------------|--------------|
-| `AddTelemetry` | Traces + metrics + logs, resource `deployment.environment` |
-| ASP.NET / HttpClient / Runtime / Npgsql | On by default |
-| `IntegrateMediator` | ActivitySource for `BuildingBlocks.Mediator` |
-| `TelemetryBuilder` | `ConfigureTracing` / `AddSource` / `AddMeter` for EF, Redis, extra meters |
-| Startup summary | One Information log of signals, exporters, and instrumentation |
-
-- Package: [NuGet · BuildingBlocks.Telemetry](https://www.nuget.org/packages/BuildingBlocks.Telemetry)
-- Release: [telemetry-v1.0.0](https://github.com/Maxofpower/FeatureManagement/releases/tag/telemetry-v1.0.0)
-- Code: [`src/BuildingBlocks.Telemetry`](src/BuildingBlocks.Telemetry)
-- Docs: [telemetry](docs/building-blocks/telemetry.md)
-
-### BuildingBlocks.Aspire.Hosting.SigNoz
-
-[![NuGet](https://img.shields.io/nuget/v/BuildingBlocks.Aspire.Hosting.SigNoz.svg?logo=nuget)](https://www.nuget.org/packages/BuildingBlocks.Aspire.Hosting.SigNoz)
-[![GitHub Release](https://img.shields.io/github/v/release/Maxofpower/FeatureManagement?filter=signoz-v*&logo=github&label=GitHub%20Release)](https://github.com/Maxofpower/FeatureManagement/releases/tag/signoz-v1.0.0)
-
-Local-dev **Aspire AppHost** integration: ClickHouse, ZooKeeper, schema migrator, OTLP collector, and SigNoz UI. **Not for production** — production still uses `BuildingBlocks.Telemetry` against any OTLP endpoint. Docker required. TFM **net10.0** (Aspire 13.4.6).
-
-#### How to use
-
-**1. Install** (AppHost project)
-
-```bash
-dotnet add package BuildingBlocks.Aspire.Hosting.SigNoz
-```
-
-**2. Compose the stack and wire the API**
-
-```csharp
-var signoz = builder.AddSigNoz("signoz")
-    .WithUi()
-    .WithDashboards();
-
-builder.AddProject<Projects.Api>("api")
-    .WithSigNozOtlpExporter(signoz);
-```
-
-**3. Run** the AppHost **https** profile. UI waits until the migrator exits 0. P95/P99 histogram tiles need the `histogramQuantile` UDF init job (also Session; Exited 0 is success).
-
-| API | Role |
-|-----|------|
-| `AddSigNoz` | ZooKeeper, ClickHouse, migrator, collector, UI |
-| `WithUi` | Host port + local admin credentials (password policy applies) |
-| `WithDashboards` | Seeds ASP.NET Core + BuildingBlocks dashboards |
-| `WithSigNozOtlpExporter` | `OTEL_EXPORTER_OTLP_*` on a **`ProjectResource` only** |
-
-- Package: [NuGet · BuildingBlocks.Aspire.Hosting.SigNoz](https://www.nuget.org/packages/BuildingBlocks.Aspire.Hosting.SigNoz)
-- Release: [signoz-v1.0.0](https://github.com/Maxofpower/FeatureManagement/releases/tag/signoz-v1.0.0)
-- Code: [`src/BuildingBlocks.Aspire.Hosting.SigNoz`](src/BuildingBlocks.Aspire.Hosting.SigNoz)
-- Docs: [telemetry](docs/building-blocks/telemetry.md) · [alerts](deploy/signoz/alerts/README.md)
-
 ### API versioning & validation
 
 Controllers + Minimal API groups; FluentValidation via controllers, generic endpoint filters, and `WithValidation` / `MapPostWithValidation`.
@@ -381,7 +434,7 @@ Redis / Memcached / memory managers, feature-flagged recommendation cache middle
 
 Reusable, type-safe keyset pagination for EF Core: Base64 JSON cursors (last value + id + sort + direction), dynamic sorting, forward/back navigation, and expression-tree filters — integrated with CQRS / Mediator.
 
-- Code: `src/FeatureFusion/Infrastructure/CursorPagination`
+- Code: `src/Lab/FeatureFusion/Infrastructure/CursorPagination`
 - Demo: product listing via `ProductService` / `PaginationHelper`
 - LinkedIn: [Reusable Cursor (keyset) Pagination](https://www.linkedin.com/feed/update/urn:li:activity:7325068550614708225/)
 
@@ -430,9 +483,10 @@ Post ↔ code map: [`docs/linkedin-posts.md`](docs/linkedin-posts.md) · [Follow
 
 ## What's next
 
-This remains a **public advanced-.NET lab**. Near-term direction (no internal delivery plan here):
+This remains a **public .NET lab**. Near-term direction:
 
-- Keep extracting reusable pieces from the Mediator / pipeline work into shareable building blocks
+- More **BuildingBlocks.\*** packages extracted from the showcase
+- Frontend showcase (`web/`, Next.js project root) and MCP (`BuildingBlocks.Mcp`) when they land
 - Keep the LinkedIn catalog in sync when new posts ship
 - Pub/sub stays a **sibling** story (not Mediator notifications)
 
@@ -441,14 +495,18 @@ This remains a **public advanced-.NET lab**. Near-term direction (no internal de
 ## Testing
 
 ```bash
-dotnet test FeatureManagementFilters.sln -c Release
+dotnet test FeatureFusion.sln -c Release
 ```
 
 | Project | Notes |
 |---------|--------|
+| `BuildingBlocks.Mediator.Tests` | Package suite on **net8 / net9 / net10** |
+| `BuildingBlocks.Mediator.Analyzers.Tests` | BBM001 / BBM002 |
+| `BuildingBlocks.Telemetry.Tests` | `AddTelemetry` / `IntegrateMediator` |
+| `BuildingBlocks.Aspire.Hosting.SigNoz.Tests` | AppHost integration |
 | `IntegrationTests` | Shared Aspire fixture — EventBus integration **and** HTTP API smoke (`Api/FeatureFusionApiTests`) |
-| `FeatureFusion.Test` | Unit / filter / mediator (single-dependency containers where useful) |
-| `FeatureFusion.ApiGateway.Test` | Memcached-backed limiter tests |
+| `FeatureFusion.Tests` | Unit / filter / mediator (single-dependency containers where useful) |
+| `FeatureFusion.ApiGateway.Tests` | Memcached-backed limiter tests |
 
 API / functional coverage uses the **Aspire** fixture in `IntegrationTests` (dynamic ports; stop a local AppHost if you still hit conflicts).
 
@@ -456,6 +514,6 @@ API / functional coverage uses the **Aspire** fixture in `IntegrationTests` (dyn
 
 ## Contributing
 
-PRs welcome. Prefer vertical-slice feature folders, XML docs on public APIs, constants over magic strings, and tests + catalog updates when behavior changes.
+PRs welcome. Prefer vertical-slice feature folders, XML docs on public APIs, constants over magic strings, and tests + catalog updates when behavior changes. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 License: **MIT** — see [LICENSE.txt](LICENSE.txt).

--- a/benchmarks/BuildingBlocks/Mediator.Benchmarks/BuildingBlocks.Mediator.Benchmarks.csproj
+++ b/benchmarks/BuildingBlocks/Mediator.Benchmarks/BuildingBlocks.Mediator.Benchmarks.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\BuildingBlocks.Mediator\BuildingBlocks.Mediator.csproj" />
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Mediator\BuildingBlocks.Mediator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/building-blocks/TEST_MATRIX.md
+++ b/docs/building-blocks/TEST_MATRIX.md
@@ -1,6 +1,6 @@
-# BuildingBlocks.Mediator v1.0 — test matrix
+# BuildingBlocks.Mediator v1.1 — test matrix
 
-Release gate: scenarios below are covered by `tests/BuildingBlocks.Mediator.Tests`
+Release gate: scenarios below are covered by `tests/BuildingBlocks/Mediator.Tests`
 on **`net8.0`**, **`net9.0`**, and **`net10.0`** (same suite per TFM).
 
 ## Supported
@@ -9,9 +9,10 @@ on **`net8.0`**, **`net9.0`**, and **`net10.0`** (same suite per TFM).
 |------|-----------|
 | Send | Command / query / void; interface variables; `Send(object)`; nested Send |
 | Pipeline | Registration order + explicit `order`; short-circuit; throw before/after; open + closed |
-| Filters | `CommandPipelineBehavior` / `QueryPipelineBehavior` skip opposite kind |
+| Filters (1.0) | `CommandPipelineBehavior` / `QueryPipelineBehavior` skip opposite kind |
+| Typed behaviors (1.1) | `ICommandPipelineBehavior` not constructed for queries; `IQueryPipelineBehavior` not constructed for commands; both in one pipeline isolate by kind; void commands; mixed with unconstrained; open-generic messages (`EchoCommand<T>` / `EchoQuery<T>`); `Result<T>` / nested `Result<PagedResult<T>>` / `IReadOnlyList<T>`; wrong kind / unconstrained / 1.0 filter base / closed type / null rejected with `ArgumentException`/`ArgumentNullException` and the matching interface name |
 | DI scan | Finds closed + open-generic handlers; Skip if pre-registered; ignores abstract/non-public |
-| Telemetry | Success / fault / omit; Activity wraps full pipeline |
+| Telemetry | Success / fault / omit; Activity wraps full pipeline; Meter duration + send counter; `EnableMetrics = false`; custom meter name |
 | ValidateOnStartup | Missing / duplicate / orphan / off; open-generic satisfies closed message |
 | Handler lifetime | `HandlerLifetime` Transient/Scoped/Singleton on discovered handlers |
 | Ambiguous handlers | Send throws when multiple closed (or multiple open) matches |
@@ -30,9 +31,9 @@ on **`net8.0`**, **`net9.0`**, and **`net10.0`** (same suite per TFM).
 | Exception handlers (recover) | Faults rethrow |
 | Pre/post processors | Use behaviors |
 | Non-generic `IQuery` | Type does not exist |
-| FV / metrics / Scrutor / other mediators in core | No package references |
+| FV / Scrutor / other mediators in core | No package references (Meter is BCL `System.Diagnostics.Metrics`) |
 | Open-generic `HandlerLifetime` | Always Transient via ActivatorUtilities |
 
 ## Edge
 
-Null message → `ArgumentNullException`; unknown `Send(object)` → `ArgumentException`; missing handler → `InvalidOperationException` with type name; bad `AddOpenBehavior` → `ArgumentException`; AddMediator without assembly → `InvalidOperationException`.
+Null message → `ArgumentNullException`; unknown `Send(object)` → `ArgumentException`; missing handler → `InvalidOperationException` with type name; bad `AddOpenBehavior` / `AddOpenCommandBehavior` / `AddOpenQueryBehavior` → `ArgumentException`; AddMediator without assembly → `InvalidOperationException`.

--- a/docs/building-blocks/cookbook.md
+++ b/docs/building-blocks/cookbook.md
@@ -1,6 +1,6 @@
 # Cookbook — host pipeline recipes
 
-BuildingBlocks.Mediator does **not** ship FluentValidation or metrics. Register host behaviors with `AddOpenBehavior`.
+BuildingBlocks.Mediator does **not** ship FluentValidation. Register host validation with `AddOpenBehavior`. Send metrics are opt-in via `UseTelemetry()` (Meter); extra host metrics can still be a behavior.
 
 ## Validation (FluentValidation)
 
@@ -93,11 +93,11 @@ Open `IPipelineBehavior<,>` that logs request type before/after `next`. Place ou
 
 ## Metrics
 
-Same pattern as logging — host-owned open behavior. Keep metrics out of `UseTelemetry`.
+`UseTelemetry()` records histogram `mediator.send.duration` (ms) and counter `mediator.send` on meter `BuildingBlocks.Mediator` unless `EnableMetrics = false`. Extra RED/business metrics stay host-owned via `AddOpenBehavior` or `ICommandPipelineBehavior`.
 
 ## Command-only / query-only
 
-Derive from `CommandPipelineBehavior<,>` or `QueryPipelineBehavior<,>` (see [pipeline-behaviors.md](pipeline-behaviors.md)).
+Prefer `ICommandPipelineBehavior` / `IQueryPipelineBehavior` (and `AddOpenCommandBehavior` / `AddOpenQueryBehavior`) so the opposite kind is never constructed. `CommandPipelineBehavior` / `QueryPipelineBehavior` remain valid 1.0.1 runtime-skip bases. See [pipeline-behaviors.md](pipeline-behaviors.md).
 
 ## Caching
 

--- a/docs/building-blocks/getting-started.md
+++ b/docs/building-blocks/getting-started.md
@@ -13,7 +13,7 @@ dotnet add package BuildingBlocks.Mediator
 Or project reference in this monorepo:
 
 ```xml
-<ProjectReference Include="..\BuildingBlocks.Mediator\BuildingBlocks.Mediator.csproj" />
+<ProjectReference Include="..\..\BuildingBlocks\Mediator\BuildingBlocks.Mediator.csproj" />
 ```
 
 ## Register
@@ -72,5 +72,26 @@ await sender.Send(new CreateOrder("SKU", 1), ct);
 var dto = await sender.Send(new GetOrder(id), ct);
 await sender.Send(new CancelOrder(id), ct);
 ```
+
+## Command-only vs query-only (1.1)
+
+Prefer constrained interfaces so MS.DI does not construct the type for the opposite kind:
+
+```csharp
+public sealed class AuditCommands<TCommand, TResponse> : ICommandPipelineBehavior<TCommand, TResponse>
+    where TCommand : ICommand<TResponse>
+{
+    public Task<TResponse> Handle(TCommand command, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+        => next(ct);
+}
+
+cfg.AddOpenCommandBehavior(typeof(AuditCommands<,>), order: 10);
+```
+
+`IQueryPipelineBehavior` / `AddOpenQueryBehavior` are the read-side pair. `CommandPipelineBehavior` / `QueryPipelineBehavior` from 1.0.1 still work (runtime skip). See [pipeline-behaviors.md](pipeline-behaviors.md).
+
+## Telemetry
+
+`cfg.UseTelemetry()` wraps Send with an ActivitySource and (by default) a Meter named `BuildingBlocks.Mediator`. Host must `AddSource` / `AddMeter` that name (`BuildingBlocks.Telemetry` does this when `IntegrateMediator` is true). Omit `UseTelemetry()` for zero overhead; `EnableMetrics = false` keeps traces only.
 
 Next: [concepts.md](concepts.md) · [pipeline-behaviors.md](pipeline-behaviors.md) · [cookbook.md](cookbook.md)

--- a/docs/building-blocks/mediator-design.md
+++ b/docs/building-blocks/mediator-design.md
@@ -39,7 +39,7 @@ sequenceDiagram
 ## Pipeline order
 
 1. Sort registered behaviors by explicit `order` (ascending), then registration index.
-2. `UseTelemetry` is optional Send enrichment (ActivitySource), not a pipeline behavior.
+2. `UseTelemetry` is optional Send enrichment (ActivitySource + Meter), not a pipeline behavior.
 3. Runtime chain: first in DI enumerable = outermost (`Reverse` when composing).
 
 ## Non-goals (v1)

--- a/docs/building-blocks/mediator.md
+++ b/docs/building-blocks/mediator.md
@@ -1,7 +1,7 @@
-# BuildingBlocks.Mediator — public interface freeze (v1)
+# BuildingBlocks.Mediator — public interface freeze (v1.1)
 
-**Status:** NuGet-ready 1.0.0 (CQRS-first Send + pipeline; no Scrutor)  
-**Date:** 2026-08-08  
+**Status:** NuGet 1.1.0 (CQRS-first Send + pipeline; typed command/query behaviors; UseTelemetry traces + metrics)  
+**Date:** 2026-08-27  
 **Author:** Mohammad Hasan Hosseini  
 **LinkedIn (prior):** https://www.linkedin.com/feed/update/urn:li:activity:7311311587372367873/  
 **Catalog:** `docs/linkedin-posts.md` → `mediator` / `mediator-building-blocks`
@@ -17,10 +17,11 @@ services.AddMediator(cfg =>
 {
     cfg.RegisterServicesFromAssembly(typeof(MyHandler).Assembly);
     cfg.AddOpenBehavior(typeof(ValidationBehavior<,>), order: 0);
-    // Optional ActivitySource enrichment around Send (not a pipeline behavior)
+    cfg.AddOpenCommandBehavior(typeof(AuditCommands<,>), order: 10);
     cfg.UseTelemetry(o =>
     {
         o.ActivitySourceName = "BuildingBlocks.Mediator";
+        o.EnableMetrics = true;
         o.RecordException = true;
         o.EnableLogging = true;
     });
@@ -38,7 +39,7 @@ Prefer `ISender` at call sites.
 
 - Explicit `order` (lower = outermost) beats registration order when set.
 - When omitted, registration index is used (first = outermost).
-- `UseTelemetry()` optionally wraps Send with an ActivitySource (pipeline + handler); omit for no telemetry.
+- `UseTelemetry()` optionally wraps Send with an ActivitySource and Meter (pipeline + handler); omit for no telemetry.
 
 ### Host validation (optional)
 
@@ -66,7 +67,8 @@ See [cookbook.md](cookbook.md).
 `IMediator : ISender` (Send only — no Publish).  
 Handlers: `ICommandHandler<>` / `ICommandHandler<,>` / `IQueryHandler<,>`.  
 Pipeline: `IPipelineBehavior<,>` — order via registration or explicit `order`.  
-Filters: `CommandPipelineBehavior` / `QueryPipelineBehavior`.  
+Typed filters: `ICommandPipelineBehavior` / `IQueryPipelineBehavior` (preferred); `AddOpenCommandBehavior` / `AddOpenQueryBehavior`.  
+1.0 filters: `CommandPipelineBehavior` / `QueryPipelineBehavior` (runtime skip; not obsolete).  
 Void commands: `ICommand : ICommand<Unit>` — behaviors on concrete type + `Unit`.  
 Scanner: built-in (no Scrutor).
 
@@ -74,14 +76,17 @@ Scanner: built-in (no Scrutor).
 
 | API | Includes | Excludes |
 |-----|----------|----------|
-| `UseTelemetry` | Activity/traces, optional ILogger, exception **observation** (rethrow) | Metrics, exception *handlers* |
-| `AddOpenBehavior` | Host cross-cutting (metrics, validation, …) | — |
+| `UseTelemetry` | Activity/traces, optional Meter (`mediator.send` / `mediator.send.duration`), optional ILogger, exception **observation** (rethrow) | Exception *handlers* |
+| `AddOpenBehavior` | Host cross-cutting (validation, extra metrics, …) | — |
+| `AddOpenCommandBehavior` / `AddOpenQueryBehavior` | Constrained open generics; fail fast if the type is not command/query-only | Unconstrained `IPipelineBehavior<,>` |
 | `HandlerLifetime` | Lifetime for discovered handlers (default Transient) | Open-generic always Transient |
 | `ValidateOnStartup` | Exactly one handler per public/nested-public closed message | — |
+
+1.0.1 hosts upgrade without code changes. New interfaces are optional.
 
 ---
 
 ## Layout
 
-`src/BuildingBlocks.Mediator/` — Abstractions, Implementation, DependencyInjection, Pipeline, Telemetry, analyzers packed from `BuildingBlocks.Mediator.Analyzers`.  
-Demo host validation: `FeatureFusion/Infrastructure/Behaviors/ValidationBehavior.cs`.
+`src/BuildingBlocks/Mediator/` — Abstractions, Implementation, DependencyInjection, Pipeline, Telemetry, analyzers packed from `BuildingBlocks.Mediator.Analyzers`.  
+Demo host validation: `src/Lab/FeatureFusion/Infrastructure/Behaviors/ValidationBehavior.cs`.

--- a/docs/building-blocks/pipeline-behaviors.md
+++ b/docs/building-blocks/pipeline-behaviors.md
@@ -4,15 +4,39 @@
 
 - Lower `order` = **outermost**.
 - When `order` is omitted, registration index is used (first registered = outermost).
-- `UseTelemetry()` is **not** a pipeline behavior — it wraps Send around the entire pipeline + handler when enabled.
+- `UseTelemetry()` is **not** a pipeline behavior — it wraps Send around the entire pipeline + handler when enabled (Activity + optional Meter).
 
 ```csharp
 cfg.AddOpenBehavior(typeof(ValidationBehavior<,>), order: 0);
-cfg.AddOpenBehavior(typeof(LoggingBehavior<,>), order: 100);
-cfg.UseTelemetry(); // optional ActivitySource enrichment around Send
+cfg.AddOpenCommandBehavior(typeof(AuditCommands<,>), order: 10);
+cfg.AddOpenQueryBehavior(typeof(CacheQueries<,>), order: 20);
+cfg.UseTelemetry();
 ```
 
-## Filters
+## Typed command / query behaviors (preferred)
+
+`ICommandPipelineBehavior<TCommand, TResponse> where TCommand : ICommand<TResponse>` and
+`IQueryPipelineBehavior<TQuery, TResponse> where TQuery : IQuery<TResponse>` are closed by MS.DI
+**only** for matching message kinds. An audit behavior is never constructed for a query.
+
+```csharp
+public sealed class AuditCommands<TCommand, TResponse> : ICommandPipelineBehavior<TCommand, TResponse>
+    where TCommand : ICommand<TResponse>
+{
+    public async Task<TResponse> Handle(
+        TCommand command, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+        => await next(ct);
+}
+
+cfg.AddOpenCommandBehavior(typeof(AuditCommands<,>), order: 10);
+// AddOpenBehavior(typeof(AuditCommands<,>)) also works — the constraint is on the type
+```
+
+`AddOpenCommandBehavior` / `AddOpenQueryBehavior` fail fast if the type does not implement the matching interface.
+
+## 1.0 runtime-skip filters (still supported)
+
+Unconstrained `CommandPipelineBehavior` / `QueryPipelineBehavior` are constructed for every Send and skip the opposite kind at runtime. Drop-in from 1.0.1 — not obsolete.
 
 ```csharp
 public sealed class MetricsOnCommands<TRequest, TResponse>
@@ -21,14 +45,9 @@ public sealed class MetricsOnCommands<TRequest, TResponse>
 {
     protected override async Task<TResponse> HandleCommand(
         TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
-    {
-        // metrics...
-        return await next(ct);
-    }
+        => await next(ct);
 }
 ```
-
-`QueryPipelineBehavior<,>` skips commands the same way.
 
 ## Cancellation
 

--- a/docs/building-blocks/telemetry.md
+++ b/docs/building-blocks/telemetry.md
@@ -82,7 +82,7 @@ Filter the category `BuildingBlocks.Telemetry.Internal.Pipeline.TelemetryStartup
 
 | Library | Emits | Host opt-in |
 |---------|-------|-------------|
-| `BuildingBlocks.Mediator` | `ActivitySource` + `ILogger` via `UseTelemetry()` | `IntegrateMediator` |
+| `BuildingBlocks.Mediator` | `ActivitySource` + Meter + `ILogger` via `UseTelemetry()` | `IntegrateMediator` (`AddSource` + `AddMeter`) |
 | EventBusRabbitMQ | `ActivitySource("EventBus")` | `Instrumentation.EventBus` |
 | SqlClient | Contrib `AddSqlClientInstrumentation` | `Instrumentation.SqlClient` + optional `ConfigureSqlClient` |
 
@@ -91,7 +91,7 @@ Filter the category `BuildingBlocks.Telemetry.Internal.Pipeline.TelemetryStartup
 | Key | Default | Meaning |
 |-----|---------|---------|
 | `EnableTracing` / `EnableMetrics` / `EnableLogging` | `true` | Pillar toggles |
-| `IntegrateMediator` | `true` | Source `BuildingBlocks.Mediator` |
+| `IntegrateMediator` | `true` | Source + meter `BuildingBlocks.Mediator` |
 | `Instrumentation.AspNetCore` | `true` | HTTP traces + metrics |
 | `Instrumentation.HttpClient` / `Runtime` / `Npgsql` | `true` | Stable |
 | `Instrumentation.IncludeFrameworkMeters` | `true` | Hosting, Kestrel, Routing, Diagnostics, Auth, MemoryPool, Http, DNS |
@@ -110,7 +110,7 @@ Vertical slices under `Internal/`: `Pipeline/`, `Exporters/`, `Instrumentations/
 
 ## SigNoz click-through (local Aspire)
 
-AppHost: `AddSigNoz().WithUi().WithDashboards()` + `WithSigNozOtlpExporter`. FeatureFusion AppHost binds UI port and admin credentials from the `SigNoz` config section (override with `SigNoz__AdminPassword`, `SigNoz__UiPort`, …) and omits `WithDataVolume()` (writable layer still persists when `Lifetime = Persistent`; sqlite volume always persists). After traffic: **Services** → **Traces** (waterfall) → **Metrics** / **Logs**. Filter spans with `telemetry.component`. Dashboard tiles use SigNoz **View in Traces**.
+AppHost: `AddSigNoz().WithUi().WithDashboards()` + `WithSigNozOtlpExporter`. FeatureFusion AppHost uses `WithUiFromConfiguration` (`src/Lab/FeatureFusion.AppHost/appsettings.Development.json`): **`dev@local.test` / `DevPassword123!`**. Override with `SigNoz__AdminEmail`, `SigNoz__AdminPassword`, `SigNoz__UiPort`, …. The UI still requires login; root-user env only skips signup. Custom lab credentials are not shown on the Aspire connection panel. Omits `WithDataVolume()` (writable layer still persists when `Lifetime = Persistent`; sqlite volume always persists). After traffic: **Services** → **Traces** (waterfall) → **Metrics** / **Logs**. Filter spans with `telemetry.component`. Dashboard tiles use SigNoz **View in Traces**.
 
 The seeded **BuildingBlocks Telemetry** dashboard has four sections — Service RED, Components (grouped by
 `telemetry.component`), Runtime (both `dotnet.*` and `process.runtime.dotnet.*` metric names, so panels work on
@@ -129,5 +129,5 @@ failing with ClickHouse `code: 754` / child process exit 2.
 
 ## Related
 
-- [BuildingBlocks.Aspire.Hosting.SigNoz](../../src/BuildingBlocks.Aspire.Hosting.SigNoz/PACKAGE_README.md)
+- [BuildingBlocks.Aspire.Hosting.SigNoz](../../src/BuildingBlocks/Aspire.Hosting.SigNoz/PACKAGE_README.md)
 - [deploy/signoz/alerts](../../deploy/signoz/alerts/README.md)

--- a/src/BuildingBlocks/Aspire.Hosting.SigNoz/AGENTS.md
+++ b/src/BuildingBlocks/Aspire.Hosting.SigNoz/AGENTS.md
@@ -1,0 +1,29 @@
+# BuildingBlocks.Aspire.Hosting.SigNoz — agent notes
+
+Local-dev Aspire AppHost integration for SigNoz. Install: `dotnet add package BuildingBlocks.Aspire.Hosting.SigNoz`. TFM: net10.0 (Aspire 13.4). Docker required.
+
+Production telemetry belongs in `BuildingBlocks.Telemetry` against an OTLP backend — this package only provisions a local SigNoz stack.
+
+## When to choose this
+
+AppHost needs a local SigNoz UI + OTLP collector (ClickHouse, ZooKeeper, schema migrator). Not for production exporters.
+
+## Register
+
+```csharp
+var signoz = builder.AddSigNoz("signoz")
+    .WithUi()
+    .WithDashboards();
+
+builder.AddProject<Projects.Api>("api")
+    .WithSigNozOtlpExporter(signoz);
+```
+
+- `WithSigNozOtlpExporter` is for `ProjectResource` only (`OTEL_EXPORTER_OTLP_*`, not `WithReference`).
+- `WithDashboards()` seeds ASP.NET Core + BuildingBlocks dashboards (match on `spec.display.name`).
+- Persist ClickHouse/ZooKeeper with `WithDataVolume()` / `WithDataBindMount()` when you need history across restarts.
+- Default `Lifetime = Persistent` plus sqlite is not a wipe each run.
+
+## Do not use for
+
+Production OTLP, non-Aspire hosts, or treating this as a substitute for `BuildingBlocks.Telemetry`.

--- a/src/BuildingBlocks/Aspire.Hosting.SigNoz/BuildingBlocks.Aspire.Hosting.SigNoz.csproj
+++ b/src/BuildingBlocks/Aspire.Hosting.SigNoz/BuildingBlocks.Aspire.Hosting.SigNoz.csproj
@@ -22,12 +22,12 @@
     <Description>Aspire AppHost (local-dev) integration for SigNoz. AddSigNoz() provisions ClickHouse, ZooKeeper, telemetrystore migrator, OTLP collector, and UI; WithDashboards() seeds ASP.NET / BuildingBlocks dashboards; WithSigNozOtlpExporter() wires projects to the collector.</Description>
     <PackageTags>aspire;hosting;signoz;opentelemetry;observability;otlp</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/Maxofpower/FeatureManagement</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Maxofpower/FeatureManagement</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/Maxofpower/FeatureFusion</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Maxofpower/FeatureFusion</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
     <PackageIcon>signoz-icon.png</PackageIcon>
-    <PackageReleaseNotes>See CHANGELOG.md in the repository for release notes.</PackageReleaseNotes>
+    <PackageReleaseNotes>1.0.0: AddSigNoz (ClickHouse, ZooKeeper, migrator, OTLP collector, UI); WithUi; WithDashboards; WithDataVolume/WithDataBindMount; WithSigNozOtlpExporter on ProjectResource. Local-dev only. https://github.com/Maxofpower/FeatureFusion/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
@@ -37,6 +37,7 @@
 
   <ItemGroup>
     <None Include="PACKAGE_README.md" Pack="true" PackagePath="\" />
+    <None Include="AGENTS.md" Pack="true" PackagePath="\" />
     <None Include="signoz-icon.png" Pack="true" PackagePath="\" />
     <None Include="PublicAPI.Shipped.txt" Pack="false" />
     <None Include="PublicAPI.Unshipped.txt" Pack="false" />

--- a/src/BuildingBlocks/Aspire.Hosting.SigNoz/PACKAGE_README.md
+++ b/src/BuildingBlocks/Aspire.Hosting.SigNoz/PACKAGE_README.md
@@ -82,8 +82,8 @@ A previously seeded copy is replaced when its layout sections no longer match th
 
 ## Docs
 
-- [Telemetry guide](https://github.com/Maxofpower/FeatureManagement/blob/main/docs/building-blocks/telemetry.md)
-- [CHANGELOG](https://github.com/Maxofpower/FeatureManagement/blob/main/CHANGELOG.md)
+- [Telemetry guide](https://github.com/Maxofpower/FeatureFusion/blob/main/docs/building-blocks/telemetry.md)
+- [CHANGELOG](https://github.com/Maxofpower/FeatureFusion/blob/main/CHANGELOG.md)
 
 ## License
 

--- a/src/BuildingBlocks/Aspire.Hosting.SigNoz/PublicAPI.Unshipped.txt
+++ b/src/BuildingBlocks/Aspire.Hosting.SigNoz/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
-# New public API for 1.0.0 — shipped at tag; keep empty for subsequent unshipped deltas.
+# New public API since 1.0.0 — move into PublicAPI.Shipped.txt when cutting the next version.
+

--- a/src/BuildingBlocks/Mediator/AGENTS.md
+++ b/src/BuildingBlocks/Mediator/AGENTS.md
@@ -1,0 +1,32 @@
+# BuildingBlocks.Mediator — agent notes
+
+CQRS **Send** + ordered pipeline for .NET 8/9/10. Install: `dotnet add package BuildingBlocks.Mediator`.
+
+## When to choose this
+
+Manual pipeline order, typed command/query behaviors, optional OpenTelemetry around Send, built-in scanner (no Scrutor). Prefer `ISender` at call sites.
+
+## Register and send
+
+```csharp
+services.AddMediator(cfg =>
+{
+    cfg.RegisterServicesFromAssemblyContaining<CreateOrderHandler>();
+    cfg.AddOpenCommandBehavior(typeof(AuditCommands<,>), order: 10);
+    cfg.AddOpenQueryBehavior(typeof(CacheQueries<,>), order: 20);
+    cfg.UseTelemetry();
+    cfg.ValidateOnStartup = true;
+});
+
+await sender.Send(new CreateOrder("SKU-1", 2), ct);
+```
+
+Markers: `ICommand` / `ICommand<T>` / `IQuery<T>` (no non-generic `IQuery`). Void writes: `ICommand : ICommand<Unit>`.
+
+Typed behaviors: `ICommandPipelineBehavior<,>` / `IQueryPipelineBehavior<,>` so MS.DI does not construct the opposite kind. 1.0 bases `CommandPipelineBehavior` / `QueryPipelineBehavior` still work (runtime skip).
+
+## Do not use for
+
+Publish / `INotification`, streaming, MediatR-style notification handlers, built-in FluentValidation, Native AOT.
+
+Host OTel: `AddSource("BuildingBlocks.Mediator")` and `AddMeter("BuildingBlocks.Mediator")` (or `BuildingBlocks.Telemetry` with `IntegrateMediator = true`).

--- a/src/BuildingBlocks/Mediator/BuildingBlocks.Mediator.csproj
+++ b/src/BuildingBlocks/Mediator/BuildingBlocks.Mediator.csproj
@@ -13,19 +13,19 @@
     <IsPackable>true</IsPackable>
     <PackageId>BuildingBlocks.Mediator</PackageId>
     <Title>BuildingBlocks.Mediator</Title>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Mohammad Hasan Hosseini</Authors>
     <Company>Mohammad Hasan Hosseini</Company>
     <Copyright>Copyright (c) 2026 Mohammad Hasan Hosseini</Copyright>
-    <Description>CQRS Send + ordered pipeline mediator building blocks. ICommand/IQuery, ISender, UseTelemetry, ValidateOnStartup, open-generic handlers. No Scrutor dependency.</Description>
-    <PackageTags>mediator;cqrs;pipeline;dotnet;net8;net9;net10</PackageTags>
+    <Description>CQRS Send + ordered pipeline mediator building blocks. ICommand/IQuery, ISender, typed command/query behaviors, UseTelemetry (traces + metrics), ValidateOnStartup, open-generic handlers. No Scrutor dependency.</Description>
+    <PackageTags>mediator;cqrs;isender;icommand;iquery;pipeline-behavior;opentelemetry;aspnetcore;dependency-injection;net8;net9;net10</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/Maxofpower/FeatureManagement</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Maxofpower/FeatureManagement</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/Maxofpower/FeatureFusion</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Maxofpower/FeatureFusion</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
     <PackageIcon>mediator-icon.png</PackageIcon>
-    <PackageReleaseNotes>See CHANGELOG.md in the repository for release notes.</PackageReleaseNotes>
+    <PackageReleaseNotes>1.1.0: Typed ICommandPipelineBehavior/IQueryPipelineBehavior; AddOpenCommandBehavior/AddOpenQueryBehavior; opt-in Send metrics (mediator.send.duration, mediator.send). Drop-in from 1.0.1. https://github.com/Maxofpower/FeatureFusion/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <None Include="PACKAGE_README.md" Pack="true" PackagePath="\" />
+    <None Include="AGENTS.md" Pack="true" PackagePath="\" />
     <None Include="mediator-icon.png" Pack="true" PackagePath="\" />
     <None Include="PublicAPI.Shipped.txt" Pack="false" />
     <None Include="PublicAPI.Unshipped.txt" Pack="false" />
@@ -50,7 +51,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BuildingBlocks.Mediator.Analyzers\BuildingBlocks.Mediator.Analyzers.csproj"
+    <ProjectReference Include="..\Mediator.Analyzers\BuildingBlocks.Mediator.Analyzers.csproj"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all" />
   </ItemGroup>
@@ -66,7 +67,7 @@
   <Target Name="PackMediatorAnalyzers" DependsOnTargets="ResolveProjectReferences"
           Condition="'$(TargetFramework)' == 'net8.0'">
     <PropertyGroup>
-      <_MediatorAnalyzerDll>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\BuildingBlocks.Mediator.Analyzers\bin\$(Configuration)\netstandard2.0\BuildingBlocks.Mediator.Analyzers.dll'))</_MediatorAnalyzerDll>
+      <_MediatorAnalyzerDll>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\Mediator.Analyzers\bin\$(Configuration)\netstandard2.0\BuildingBlocks.Mediator.Analyzers.dll'))</_MediatorAnalyzerDll>
     </PropertyGroup>
     <Error Condition="!Exists('$(_MediatorAnalyzerDll)')"
            Text="Mediator analyzer DLL not found at '$(_MediatorAnalyzerDll)'. Build BuildingBlocks.Mediator.Analyzers first." />

--- a/src/BuildingBlocks/Mediator/DependencyInjection/MediatorServiceCollectionExtensions.cs
+++ b/src/BuildingBlocks/Mediator/DependencyInjection/MediatorServiceCollectionExtensions.cs
@@ -19,8 +19,8 @@ namespace BuildingBlocks.Mediator.DependencyInjection;
 /// </para>
 /// <para>
 /// <see cref="UseTelemetry"/> is optional. When enabled it registers an ActivitySource
-/// (name configurable) and wraps each Send around the full pipeline + handler — it does
-/// <strong>not</strong> add a pipeline behavior.
+/// (name configurable) and, unless metrics are disabled, a Meter, and wraps each Send around
+/// the full pipeline + handler — it does <strong>not</strong> add a pipeline behavior.
 /// </para>
 /// </remarks>
 /// <example>
@@ -75,16 +75,20 @@ public sealed class MediatorConfiguration
 		=> RegisterServicesFromAssembly(typeof(T).Assembly);
 
 	/// <summary>
-	/// Enables optional Send enrichment via a configurable <see cref="System.Diagnostics.ActivitySource"/>.
+	/// Enables optional Send enrichment via a configurable <see cref="System.Diagnostics.ActivitySource"/>
+	/// and, unless <see cref="MediatorTelemetryOptions.EnableMetrics"/> is false, a
+	/// <see cref="System.Diagnostics.Metrics.Meter"/>.
 	/// Activity wraps the full pipeline + handler (not a pipeline behavior). Omit this call for zero telemetry overhead.
 	/// </summary>
-	/// <param name="configure">Optional; set <see cref="MediatorTelemetryOptions.ActivitySourceName"/> and logging/exception flags.</param>
+	/// <param name="configure">Optional; set <see cref="MediatorTelemetryOptions.ActivitySourceName"/>, meter, logging, and exception flags.</param>
 	public MediatorConfiguration UseTelemetry(Action<MediatorTelemetryOptions>? configure = null)
 	{
 		var options = new MediatorTelemetryOptions();
 		configure?.Invoke(options);
 		if (string.IsNullOrWhiteSpace(options.ActivitySourceName))
 			throw new ArgumentException("ActivitySourceName must be a non-empty string when UseTelemetry is enabled.", nameof(configure));
+		if (string.IsNullOrWhiteSpace(options.MeterName))
+			options.MeterName = options.ActivitySourceName;
 		TelemetryOptions = options;
 		return this;
 	}
@@ -150,20 +154,7 @@ public sealed class MediatorConfiguration
 		int? order,
 		ServiceLifetime serviceLifetime)
 	{
-		ArgumentNullException.ThrowIfNull(openBehaviorType);
-
-		if (!openBehaviorType.IsGenericTypeDefinition)
-			throw new ArgumentException(
-				$"{openBehaviorType.Name} must be an open generic type definition (e.g. MyBehavior&lt;,&gt;).",
-				nameof(openBehaviorType));
-
-		var implementsPipeline = openBehaviorType.GetInterfaces()
-			.Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IPipelineBehavior<,>));
-
-		if (!implementsPipeline)
-			throw new ArgumentException(
-				$"{openBehaviorType.Name} must implement IPipelineBehavior&lt;,&gt;.",
-				nameof(openBehaviorType));
+		EnsureOpenPipelineBehavior(openBehaviorType, typeof(IPipelineBehavior<,>), nameof(openBehaviorType));
 
 		var index = _nextRegistrationIndex++;
 		var effectiveOrder = order ?? index;
@@ -177,6 +168,97 @@ public sealed class MediatorConfiguration
 			index));
 
 		return this;
+	}
+
+	/// <summary>
+	/// Registers an open-generic command-only pipeline behavior
+	/// (must implement <see cref="Pipeline.ICommandPipelineBehavior{TCommand,TResponse}"/>).
+	/// When order is omitted, registration order is used (first registered = outermost).
+	/// </summary>
+	public MediatorConfiguration AddOpenCommandBehavior(
+		Type openBehaviorType,
+		ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+		=> AddOpenCommandBehavior(openBehaviorType, order: null, serviceLifetime);
+
+	/// <summary>
+	/// Registers an open-generic command-only pipeline behavior with an explicit
+	/// <paramref name="order"/> (lower = outermost).
+	/// </summary>
+	public MediatorConfiguration AddOpenCommandBehavior(
+		Type openBehaviorType,
+		int order,
+		ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+		=> AddOpenCommandBehavior(openBehaviorType, (int?)order, serviceLifetime);
+
+	internal MediatorConfiguration AddOpenCommandBehavior(
+		Type openBehaviorType,
+		int? order,
+		ServiceLifetime serviceLifetime)
+	{
+		EnsureOpenPipelineBehavior(
+			openBehaviorType,
+			typeof(Pipeline.ICommandPipelineBehavior<,>),
+			nameof(openBehaviorType),
+			"ICommandPipelineBehavior");
+		return AddOpenBehavior(openBehaviorType, order, serviceLifetime);
+	}
+
+	/// <summary>
+	/// Registers an open-generic query-only pipeline behavior
+	/// (must implement <see cref="Pipeline.IQueryPipelineBehavior{TQuery,TResponse}"/>).
+	/// When order is omitted, registration order is used (first registered = outermost).
+	/// </summary>
+	public MediatorConfiguration AddOpenQueryBehavior(
+		Type openBehaviorType,
+		ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+		=> AddOpenQueryBehavior(openBehaviorType, order: null, serviceLifetime);
+
+	/// <summary>
+	/// Registers an open-generic query-only pipeline behavior with an explicit
+	/// <paramref name="order"/> (lower = outermost).
+	/// </summary>
+	public MediatorConfiguration AddOpenQueryBehavior(
+		Type openBehaviorType,
+		int order,
+		ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+		=> AddOpenQueryBehavior(openBehaviorType, (int?)order, serviceLifetime);
+
+	internal MediatorConfiguration AddOpenQueryBehavior(
+		Type openBehaviorType,
+		int? order,
+		ServiceLifetime serviceLifetime)
+	{
+		EnsureOpenPipelineBehavior(
+			openBehaviorType,
+			typeof(Pipeline.IQueryPipelineBehavior<,>),
+			nameof(openBehaviorType),
+			"IQueryPipelineBehavior");
+		return AddOpenBehavior(openBehaviorType, order, serviceLifetime);
+	}
+
+	private static void EnsureOpenPipelineBehavior(
+		Type openBehaviorType,
+		Type requiredOpenInterface,
+		string paramName,
+		string? requiredInterfaceDisplayName = null)
+	{
+		ArgumentNullException.ThrowIfNull(openBehaviorType);
+
+		if (!openBehaviorType.IsGenericTypeDefinition)
+			throw new ArgumentException(
+				$"{openBehaviorType.Name} must be an open generic type definition (e.g. MyBehavior&lt;,&gt;).",
+				paramName);
+
+		var implements = openBehaviorType.GetInterfaces()
+			.Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == requiredOpenInterface);
+
+		if (!implements)
+		{
+			var iface = requiredInterfaceDisplayName ?? "IPipelineBehavior";
+			throw new ArgumentException(
+				$"{openBehaviorType.Name} must implement {iface}&lt;,&gt;.",
+				paramName);
+		}
 	}
 }
 

--- a/src/BuildingBlocks/Mediator/PACKAGE_README.md
+++ b/src/BuildingBlocks/Mediator/PACKAGE_README.md
@@ -1,15 +1,33 @@
 # BuildingBlocks.Mediator
 
-CQRS-first **Send** + ordered **pipeline** mediator for .NET — `ICommand` / `IQuery`, `ISender`, host behaviors, optional telemetry, and startup handler validation.
+CQRS-first **Send** + ordered **pipeline** for .NET 8+. Commands and queries, host-owned behaviors, optional traces and metrics, startup handler checks.
 
 [![NuGet](https://img.shields.io/nuget/v/BuildingBlocks.Mediator.svg)](https://www.nuget.org/packages/BuildingBlocks.Mediator)
+[![.NET](https://img.shields.io/badge/.NET-8%20%7C%209%20%7C%2010-512BD4)](https://dotnet.microsoft.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-> **Disclaimer:** BuildingBlocks.Mediator is **not** designed to replace other mediator or messaging packages. It is a focused CQRS Send + pipeline building block for developers who want **manual control** over design patterns — registration, pipeline order, validation, telemetry, and host composition — rather than a batteries-included framework.
+**When to use:** you want manual pipeline order, typed command/query behaviors, optional OpenTelemetry around Send, and a built-in scanner (no Scrutor).
 
-## Requirements
+## What's new in 1.1.0
 
-- **.NET 8**, **.NET 9**, or **.NET 10** (`net8.0` / `net9.0` / `net10.0`)
+- Typed `ICommandPipelineBehavior` / `IQueryPipelineBehavior` — MS.DI does not construct the opposite kind
+- `AddOpenCommandBehavior` / `AddOpenQueryBehavior` fail fast when the type is unconstrained
+- Opt-in Send metrics on `UseTelemetry()` (histogram `mediator.send.duration`, counter `mediator.send`)
+- Drop-in from 1.0.1 (`CommandPipelineBehavior` / `QueryPipelineBehavior` unchanged)
+
+## Features
+
+- **CQRS markers:** `ICommand` / `ICommand<T>` / `IQuery<T>` (no non-generic `IQuery`)
+- **Void commands:** `ICommand : ICommand<Unit>` — pipeline binds to the real command type
+- **Ordered pipeline:** open/closed behaviors with optional `order` (lower = outermost)
+- **Typed command/query behaviors:** `ICommandPipelineBehavior` / `IQueryPipelineBehavior` — MS.DI does not construct them for the opposite kind
+- **1.0 filter bases still work:** `CommandPipelineBehavior` / `QueryPipelineBehavior` skip the other kind at runtime
+- **`UseTelemetry()`:** optional ActivitySource + Meter around Send (not a pipeline behavior)
+- **`ValidateOnStartup`:** missing/duplicate handlers at registration
+- **Exact-one handler** at Send, with clear errors
+- **Open-generic handlers** closed on demand
+- **Built-in scanner** — no Scrutor
+- **Roslyn analyzers** BBM001 / BBM002 packed in the NuGet
 
 ## Install
 
@@ -17,57 +35,115 @@ CQRS-first **Send** + ordered **pipeline** mediator for .NET — `ICommand` / `I
 dotnet add package BuildingBlocks.Mediator
 ```
 
-## 60-second quick start
+Requires **.NET 8**, **.NET 9**, or **.NET 10**.
+
+## Quick start
+
+**1. Define a command and handler**
 
 ```csharp
-services.AddMediator(cfg =>
-{
-    cfg.RegisterServicesFromAssemblyContaining<CreateOrderHandler>();
-    cfg.AddOpenBehavior(typeof(ValidationBehavior<,>), order: 0);
-    cfg.UseTelemetry();
-    cfg.ValidateOnStartup = true;
-});
-
 public sealed record CreateOrder(string Product, int Qty) : ICommand<OrderId>;
+
 public sealed class CreateOrderHandler : ICommandHandler<CreateOrder, OrderId>
 {
     public Task<OrderId> Handle(CreateOrder command, CancellationToken ct)
         => Task.FromResult(new OrderId(Guid.NewGuid()));
 }
-
-// Prefer ISender at call sites
-await sender.Send(new CreateOrder("SKU-1", 2), ct);
 ```
 
-## Features
+**2. Register**
 
-- CQRS markers: `ICommand` / `ICommand<T>` / `IQuery<T>` (no non-generic `IQuery`)
-- Void commands via `ICommand : ICommand<Unit>` (pipeline on the real type)
-- Ordered open/closed pipeline behaviors (`AddOpenBehavior` + optional `order`)
-- `CommandPipelineBehavior` / `QueryPipelineBehavior` filter bases
-- `UseTelemetry` — optional ActivitySource enrichment around Send (wraps pipeline + handler; not a behavior)
-- `ValidateOnStartup` — missing/duplicate handler checks at registration
-- `HandlerLifetime` — configure discovered handler lifetime (default Transient)
-- Exact-one handler resolution at Send (clear errors for missing/ambiguous handlers)
-- Open-generic handlers — scanned and closed on demand
-- Built-in assembly scanner — **no Scrutor dependency**
+```csharp
+services.AddMediator(cfg =>
+{
+    cfg.RegisterServicesFromAssemblyContaining<CreateOrderHandler>();
+    cfg.AddOpenBehavior(typeof(ValidationBehavior<,>), order: 0); // host-owned
+    cfg.UseTelemetry();          // traces + metrics (omit for zero overhead)
+    cfg.ValidateOnStartup = true;
+});
+```
+
+**3. Send** — prefer `ISender` at call sites
+
+```csharp
+await sender.Send(new CreateOrder("SKU-1", 2), ct);
+var dto = await sender.Send(new GetOrder(id), ct);
+await sender.Send(new CancelOrder(id), ct); // ICommand (void)
+```
+
+## Command-only vs query-only behaviors
+
+Use constrained interfaces so a caching behavior is never constructed for a write, and an audit/transaction behavior is never constructed for a read:
+
+```csharp
+public sealed class AuditCommands<TCommand, TResponse> : ICommandPipelineBehavior<TCommand, TResponse>
+    where TCommand : ICommand<TResponse>
+{
+    public async Task<TResponse> Handle(
+        TCommand command, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+        => await next(ct);
+}
+
+public sealed class CacheQueries<TQuery, TResponse> : IQueryPipelineBehavior<TQuery, TResponse>
+    where TQuery : IQuery<TResponse>
+{
+    public async Task<TResponse> Handle(
+        TQuery query, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+        => await next(ct);
+}
+
+cfg.AddOpenCommandBehavior(typeof(AuditCommands<,>), order: 10);
+cfg.AddOpenQueryBehavior(typeof(CacheQueries<,>), order: 20);
+// AddOpenBehavior(typeof(AuditCommands<,>)) also works — the constraint is on the type
+```
+
+`CommandPipelineBehavior` / `QueryPipelineBehavior` from 1.0.1 remain supported (runtime skip). Prefer the interfaces for new code.
+
+## Telemetry
+
+`UseTelemetry()` wraps **pipeline + handler** (not a behavior):
+
+- **Traces:** ActivitySource `BuildingBlocks.Mediator`
+- **Metrics:** Meter `BuildingBlocks.Mediator` — histogram `mediator.send.duration` (ms), counter `mediator.send` (`mediator.success`, `mediator.message_kind`, `mediator.request_name`)
+
+```csharp
+cfg.UseTelemetry(o =>
+{
+    o.ActivitySourceName = "BuildingBlocks.Mediator"; // MeterName copies this when unset
+    o.EnableMetrics = true;   // default
+    o.EnableLogging = true;
+    o.RecordException = true;
+});
+```
+
+Host OpenTelemetry (or `BuildingBlocks.Telemetry` with `IntegrateMediator = true`):
+
+```csharp
+.WithTracing(t => t.AddSource("BuildingBlocks.Mediator"))
+.WithMetrics(m => m.AddMeter("BuildingBlocks.Mediator"));
+```
+
+Omit `UseTelemetry()` for zero library telemetry overhead. Set `EnableMetrics = false` to keep traces without meters.
+
+Validation stays host-owned (FluentValidation + `AddOpenBehavior`). See the cookbook.
 
 ## What it is not (v1)
 
-- No `Publish` / `INotification`
+- Not a MediatR or messaging replacement
+- No `Publish` / `INotification` (use your event bus)
 - No streaming (`CreateStream`)
 - No exception *handlers* that replace results (faults rethrow)
-- No built-in FluentValidation or metrics (host `AddOpenBehavior`)
+- No built-in FluentValidation
 - Not fully Native AOT (runtime `MakeGenericType` wrappers)
 - Open-generic handlers always resolve as Transient (ignore `HandlerLifetime`)
 
 ## Docs
 
-- [Getting started](https://github.com/Maxofpower/FeatureManagement/blob/main/docs/building-blocks/getting-started.md)
-- [Pipeline behaviors](https://github.com/Maxofpower/FeatureManagement/blob/main/docs/building-blocks/pipeline-behaviors.md)
-- [Cookbook](https://github.com/Maxofpower/FeatureManagement/blob/main/docs/building-blocks/cookbook.md)
-- [v1.0 test matrix](https://github.com/Maxofpower/FeatureManagement/blob/main/docs/building-blocks/TEST_MATRIX.md)
-- [CHANGELOG](https://github.com/Maxofpower/FeatureManagement/blob/main/CHANGELOG.md)
+- [Getting started](https://github.com/Maxofpower/FeatureFusion/blob/main/docs/building-blocks/getting-started.md)
+- [Pipeline behaviors](https://github.com/Maxofpower/FeatureFusion/blob/main/docs/building-blocks/pipeline-behaviors.md)
+- [Cookbook](https://github.com/Maxofpower/FeatureFusion/blob/main/docs/building-blocks/cookbook.md)
+- [Test matrix](https://github.com/Maxofpower/FeatureFusion/blob/main/docs/building-blocks/TEST_MATRIX.md)
+- [CHANGELOG](https://github.com/Maxofpower/FeatureFusion/blob/main/CHANGELOG.md)
 
 Demo host: **FeatureFusion** in the same repository.
 

--- a/src/BuildingBlocks/Mediator/Pipeline/CommandPipelineBehavior.cs
+++ b/src/BuildingBlocks/Mediator/Pipeline/CommandPipelineBehavior.cs
@@ -4,6 +4,11 @@ namespace BuildingBlocks.Mediator.Pipeline;
 /// Pipeline behavior that runs only for command requests (<see cref="ICommand"/> / <see cref="ICommand{TResponse}"/>).
 /// Queries skip straight to the next delegate without invoking <see cref="HandleCommand"/>.
 /// </summary>
+/// <remarks>
+/// Prefer <see cref="ICommandPipelineBehavior{TCommand,TResponse}"/> for new open generics so MS.DI
+/// does not construct this type for queries. This base remains supported (1.0.1 contract): it is
+/// unconstrained and skips the opposite kind at runtime.
+/// </remarks>
 /// <typeparam name="TRequest">Request type.</typeparam>
 /// <typeparam name="TResponse">Response type (use <see cref="Unit"/> for void commands).</typeparam>
 /// <example>

--- a/src/BuildingBlocks/Mediator/Pipeline/ICommandPipelineBehavior.cs
+++ b/src/BuildingBlocks/Mediator/Pipeline/ICommandPipelineBehavior.cs
@@ -1,0 +1,32 @@
+namespace BuildingBlocks.Mediator.Pipeline;
+
+/// <summary>
+/// Pipeline behavior that applies only to commands.
+/// </summary>
+/// <remarks>
+/// Prefer this over <see cref="CommandPipelineBehavior{TRequest,TResponse}"/> when registering an
+/// open generic via <c>AddOpenBehavior</c> / <c>AddOpenCommandBehavior</c>. The
+/// <see cref="ICommand{TResponse}"/> constraint means MS.DI will not close (or construct) the type
+/// for queries. The 1.0 filter base still works: it is constructed for every Send and skips queries
+/// at runtime.
+/// </remarks>
+/// <typeparam name="TCommand">Command type.</typeparam>
+/// <typeparam name="TResponse">Response type (use <see cref="Unit"/> for void commands).</typeparam>
+/// <example>
+/// <code>
+/// public sealed class AuditCommands&lt;TCommand, TResponse&gt; : ICommandPipelineBehavior&lt;TCommand, TResponse&gt;
+///     where TCommand : ICommand&lt;TResponse&gt;
+/// {
+///     public async Task&lt;TResponse&gt; Handle(
+///         TCommand command, RequestHandlerDelegate&lt;TResponse&gt; next, CancellationToken ct)
+///         =&gt; await next(ct);
+/// }
+///
+/// cfg.AddOpenBehavior(typeof(AuditCommands&lt;,&gt;), order: 10);
+/// // or cfg.AddOpenCommandBehavior(typeof(AuditCommands&lt;,&gt;), order: 10);
+/// </code>
+/// </example>
+public interface ICommandPipelineBehavior<in TCommand, TResponse> : IPipelineBehavior<TCommand, TResponse>
+	where TCommand : ICommand<TResponse>
+{
+}

--- a/src/BuildingBlocks/Mediator/Pipeline/IQueryPipelineBehavior.cs
+++ b/src/BuildingBlocks/Mediator/Pipeline/IQueryPipelineBehavior.cs
@@ -1,0 +1,32 @@
+namespace BuildingBlocks.Mediator.Pipeline;
+
+/// <summary>
+/// Pipeline behavior that applies only to queries.
+/// </summary>
+/// <remarks>
+/// Prefer this over <see cref="QueryPipelineBehavior{TRequest,TResponse}"/> when registering an
+/// open generic via <c>AddOpenBehavior</c> / <c>AddOpenQueryBehavior</c>. The
+/// <see cref="IQuery{TResponse}"/> constraint means MS.DI will not close (or construct) the type
+/// for commands. The 1.0 filter base still works: it is constructed for every Send and skips commands
+/// at runtime.
+/// </remarks>
+/// <typeparam name="TQuery">Query type.</typeparam>
+/// <typeparam name="TResponse">Read model / DTO / Result&lt;T&gt;.</typeparam>
+/// <example>
+/// <code>
+/// public sealed class CacheQueries&lt;TQuery, TResponse&gt; : IQueryPipelineBehavior&lt;TQuery, TResponse&gt;
+///     where TQuery : IQuery&lt;TResponse&gt;
+/// {
+///     public async Task&lt;TResponse&gt; Handle(
+///         TQuery query, RequestHandlerDelegate&lt;TResponse&gt; next, CancellationToken ct)
+///         =&gt; await next(ct);
+/// }
+///
+/// cfg.AddOpenBehavior(typeof(CacheQueries&lt;,&gt;), order: 20);
+/// // or cfg.AddOpenQueryBehavior(typeof(CacheQueries&lt;,&gt;), order: 20);
+/// </code>
+/// </example>
+public interface IQueryPipelineBehavior<in TQuery, TResponse> : IPipelineBehavior<TQuery, TResponse>
+	where TQuery : IQuery<TResponse>
+{
+}

--- a/src/BuildingBlocks/Mediator/Pipeline/QueryPipelineBehavior.cs
+++ b/src/BuildingBlocks/Mediator/Pipeline/QueryPipelineBehavior.cs
@@ -4,6 +4,11 @@ namespace BuildingBlocks.Mediator.Pipeline;
 /// Pipeline behavior that runs only for query requests (<see cref="IQuery{TResponse}"/>).
 /// Commands skip straight to the next delegate without invoking <see cref="HandleQuery"/>.
 /// </summary>
+/// <remarks>
+/// Prefer <see cref="IQueryPipelineBehavior{TQuery,TResponse}"/> for new open generics so MS.DI
+/// does not construct this type for commands. This base remains supported (1.0.1 contract): it is
+/// unconstrained and skips the opposite kind at runtime.
+/// </remarks>
 /// <typeparam name="TRequest">Request type.</typeparam>
 /// <typeparam name="TResponse">Response type.</typeparam>
 /// <example>

--- a/src/BuildingBlocks/Mediator/PublicAPI.Shipped.txt
+++ b/src/BuildingBlocks/Mediator/PublicAPI.Shipped.txt
@@ -66,6 +66,10 @@ namespace BuildingBlocks.Mediator.DependencyInjection
         public BuildingBlocks.Mediator.DependencyInjection.MediatorConfiguration AddBehavior<TBehavior>(int order) where TBehavior : class { throw null!; }
         public BuildingBlocks.Mediator.DependencyInjection.MediatorConfiguration AddOpenBehavior(System.Type openBehaviorType, Microsoft.Extensions.DependencyInjection.ServiceLifetime serviceLifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient) { throw null!; }
         public BuildingBlocks.Mediator.DependencyInjection.MediatorConfiguration AddOpenBehavior(System.Type openBehaviorType, int order, Microsoft.Extensions.DependencyInjection.ServiceLifetime serviceLifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient) { throw null!; }
+        public BuildingBlocks.Mediator.DependencyInjection.MediatorConfiguration AddOpenCommandBehavior(System.Type openBehaviorType, Microsoft.Extensions.DependencyInjection.ServiceLifetime serviceLifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient) { throw null!; }
+        public BuildingBlocks.Mediator.DependencyInjection.MediatorConfiguration AddOpenCommandBehavior(System.Type openBehaviorType, int order, Microsoft.Extensions.DependencyInjection.ServiceLifetime serviceLifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient) { throw null!; }
+        public BuildingBlocks.Mediator.DependencyInjection.MediatorConfiguration AddOpenQueryBehavior(System.Type openBehaviorType, Microsoft.Extensions.DependencyInjection.ServiceLifetime serviceLifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient) { throw null!; }
+        public BuildingBlocks.Mediator.DependencyInjection.MediatorConfiguration AddOpenQueryBehavior(System.Type openBehaviorType, int order, Microsoft.Extensions.DependencyInjection.ServiceLifetime serviceLifetime = Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient) { throw null!; }
     }
     public static class MediatorServiceCollectionExtensions
     {
@@ -84,6 +88,8 @@ namespace BuildingBlocks.Mediator.Pipeline
         public System.Threading.Tasks.Task<TResponse> Handle(TRequest request, BuildingBlocks.Mediator.RequestHandlerDelegate<TResponse> next, System.Threading.CancellationToken cancellationToken = default) { throw null!; }
         protected abstract System.Threading.Tasks.Task<TResponse> HandleQuery(TRequest request, BuildingBlocks.Mediator.RequestHandlerDelegate<TResponse> next, System.Threading.CancellationToken cancellationToken);
     }
+    public interface ICommandPipelineBehavior<in TCommand, TResponse> : BuildingBlocks.Mediator.IPipelineBehavior<TCommand, TResponse> where TCommand : BuildingBlocks.Mediator.ICommand<TResponse> { }
+    public interface IQueryPipelineBehavior<in TQuery, TResponse> : BuildingBlocks.Mediator.IPipelineBehavior<TQuery, TResponse> where TQuery : BuildingBlocks.Mediator.IQuery<TResponse> { }
     public static class MessageKind
     {
         public static bool IsCommand(object request) { throw null!; }
@@ -95,14 +101,18 @@ namespace BuildingBlocks.Mediator.Telemetry
     public sealed class MediatorTelemetryOptions
     {
         public string ActivitySourceName { get { throw null!; } set { } }
+        public string MeterName { get { throw null!; } set { } }
         public bool RecordException { get { throw null!; } set { } }
         public bool EnableLogging { get { throw null!; } set { } }
+        public bool EnableMetrics { get { throw null!; } set { } }
     }
-    public sealed class MediatorSendTelemetry
+    public sealed class MediatorSendTelemetry : System.IDisposable
     {
         public MediatorSendTelemetry(Microsoft.Extensions.Options.IOptions<BuildingBlocks.Mediator.Telemetry.MediatorTelemetryOptions> options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
         public string ActivitySourceName { get { throw null!; } }
+        public string? MeterName { get { throw null!; } }
         public System.Diagnostics.ActivitySource Source { get { throw null!; } }
         public System.Threading.Tasks.Task<TResponse> TraceAsync<TResponse>(System.Type messageType, string messageKind, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<TResponse>> send, System.Threading.CancellationToken cancellationToken) { throw null!; }
+        public void Dispose() { }
     }
 }

--- a/src/BuildingBlocks/Mediator/PublicAPI.Unshipped.txt
+++ b/src/BuildingBlocks/Mediator/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-# New public API for 1.0.0 — shipped at tag; keep empty for subsequent unshipped deltas.
+# New public API since 1.1.0 — move into PublicAPI.Shipped.txt when cutting the next version.

--- a/src/BuildingBlocks/Mediator/Telemetry/MediatorSendTelemetry.cs
+++ b/src/BuildingBlocks/Mediator/Telemetry/MediatorSendTelemetry.cs
@@ -1,18 +1,23 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace BuildingBlocks.Mediator.Telemetry;
 
 /// <summary>
-/// Optional Send enrichment (Activity + logging + exception observation).
+/// Optional Send enrichment (Activity + logging + exception observation + opt-in metrics).
 /// Wraps the full pipeline + handler — not registered as an <see cref="IPipelineBehavior{TRequest,TResponse}"/>.
 /// </summary>
-public sealed class MediatorSendTelemetry
+public sealed class MediatorSendTelemetry : IDisposable
 {
 	private readonly ActivitySource _activitySource;
 	private readonly MediatorTelemetryOptions _options;
 	private readonly ILogger _logger;
+	private readonly Meter? _meter;
+	private readonly Histogram<double>? _duration;
+	private readonly Counter<long>? _send;
+	private bool _disposed;
 
 	/// <summary>Creates Send telemetry using configured options.</summary>
 	public MediatorSendTelemetry(
@@ -22,10 +27,23 @@ public sealed class MediatorSendTelemetry
 		_options = options.Value;
 		_activitySource = new ActivitySource(_options.ActivitySourceName);
 		_logger = loggerFactory.CreateLogger("BuildingBlocks.Mediator.Telemetry");
+
+		if (_options.EnableMetrics)
+		{
+			var meterName = string.IsNullOrWhiteSpace(_options.MeterName)
+				? _options.ActivitySourceName
+				: _options.MeterName;
+			_meter = new Meter(meterName);
+			_duration = _meter.CreateHistogram<double>("mediator.send.duration", unit: "ms");
+			_send = _meter.CreateCounter<long>("mediator.send");
+		}
 	}
 
 	/// <summary>Activity source name (for host <c>AddSource</c>).</summary>
 	public string ActivitySourceName => _activitySource.Name;
+
+	/// <summary>Meter name when metrics are enabled; otherwise <see langword="null"/>.</summary>
+	public string? MeterName => _meter?.Name;
 
 	/// <summary>The underlying <see cref="ActivitySource"/>.</summary>
 	public ActivitySource Source => _activitySource;
@@ -41,6 +59,7 @@ public sealed class MediatorSendTelemetry
 		Func<CancellationToken, Task<TResponse>> send,
 		CancellationToken cancellationToken)
 	{
+		ObjectDisposedException.ThrowIf(_disposed, this);
 		ArgumentNullException.ThrowIfNull(messageType);
 		ArgumentNullException.ThrowIfNull(messageKind);
 		ArgumentNullException.ThrowIfNull(send);
@@ -64,6 +83,8 @@ public sealed class MediatorSendTelemetry
 			activity?.SetTag("mediator.success", true);
 			activity?.SetTag("mediator.duration_ms", stopwatch.ElapsedMilliseconds);
 
+			RecordMetrics(requestName, messageKind, success: true, stopwatch.Elapsed.TotalMilliseconds);
+
 			if (_options.EnableLogging)
 			{
 				_logger.LogInformation(
@@ -81,6 +102,8 @@ public sealed class MediatorSendTelemetry
 			activity?.SetTag("mediator.success", false);
 			activity?.SetTag("mediator.duration_ms", stopwatch.ElapsedMilliseconds);
 			activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
+			RecordMetrics(requestName, messageKind, success: false, stopwatch.Elapsed.TotalMilliseconds);
 
 			if (_options.RecordException)
 			{
@@ -103,5 +126,36 @@ public sealed class MediatorSendTelemetry
 
 			throw;
 		}
+	}
+
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		if (_disposed)
+			return;
+		_disposed = true;
+		_meter?.Dispose();
+		_activitySource.Dispose();
+	}
+
+	private void RecordMetrics(string requestName, string messageKind, bool success, double elapsedMs)
+	{
+		if (_duration is null || _send is null)
+			return;
+
+		var durationTags = new TagList
+		{
+			{ "mediator.message_kind", messageKind },
+			{ "mediator.request_name", requestName },
+		};
+		_duration.Record(elapsedMs, durationTags);
+
+		var countTags = new TagList
+		{
+			{ "mediator.message_kind", messageKind },
+			{ "mediator.request_name", requestName },
+			{ "mediator.success", success },
+		};
+		_send.Add(1, countTags);
 	}
 }

--- a/src/BuildingBlocks/Mediator/Telemetry/MediatorTelemetryOptions.cs
+++ b/src/BuildingBlocks/Mediator/Telemetry/MediatorTelemetryOptions.cs
@@ -2,7 +2,9 @@ namespace BuildingBlocks.Mediator.Telemetry;
 
 /// <summary>
 /// Options for optional Send enrichment via <c>UseTelemetry</c>.
-/// Activity wraps the full pipeline + handler (not a pipeline behavior). Metrics stay host-owned.
+/// Activity wraps the full pipeline + handler (not a pipeline behavior).
+/// When <see cref="EnableMetrics"/> is true, a <c>Meter</c> records Send duration and counts.
+/// Omit <c>UseTelemetry</c> for zero telemetry overhead.
 /// </summary>
 public sealed class MediatorTelemetryOptions
 {
@@ -12,9 +14,21 @@ public sealed class MediatorTelemetryOptions
 	/// </summary>
 	public string ActivitySourceName { get; set; } = "BuildingBlocks.Mediator";
 
+	/// <summary>
+	/// <see cref="System.Diagnostics.Metrics.Meter"/> name. Host OpenTelemetry must
+	/// <c>AddMeter</c> this value. When unset, <c>UseTelemetry</c> copies <see cref="ActivitySourceName"/>.
+	/// </summary>
+	public string MeterName { get; set; } = "";
+
 	/// <summary>When true, faults set Activity error status and record the exception.</summary>
 	public bool RecordException { get; set; } = true;
 
 	/// <summary>When true, logs start/end (and errors) via <see cref="Microsoft.Extensions.Logging.ILogger"/>.</summary>
 	public bool EnableLogging { get; set; } = true;
+
+	/// <summary>
+	/// When true (default), records <c>mediator.send.duration</c> (histogram, ms) and
+	/// <c>mediator.send</c> (counter) on the meter named <see cref="MeterName"/>.
+	/// </summary>
+	public bool EnableMetrics { get; set; } = true;
 }

--- a/src/BuildingBlocks/Telemetry/AGENTS.md
+++ b/src/BuildingBlocks/Telemetry/AGENTS.md
@@ -1,0 +1,23 @@
+# BuildingBlocks.Telemetry — agent notes
+
+Config-driven OpenTelemetry traces, metrics, and logs for .NET 8/9/10. Install: `dotnet add package BuildingBlocks.Telemetry`. Requires `IHostApplicationBuilder` (`Microsoft.AspNetCore.App`).
+
+## When to choose this
+
+One `AddTelemetry` call for ASP.NET Core / HttpClient / Runtime / Npgsql (SqlClient opt-in), plus source-only Mediator / EventBus / MassTransit. Exporters: OTLP (env fast-path), Console, Azure Monitor.
+
+## Register
+
+```csharp
+builder.AddTelemetry(o =>
+{
+    o.IntegrateMediator = true; // AddSource + AddMeter for BuildingBlocks.Mediator
+    o.Instrumentation.Npgsql = true;
+});
+```
+
+OTLP turns on when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Prefer env over hard-coded endpoints.
+
+## 1.0.1
+
+`IntegrateMediator` also `AddMeter("BuildingBlocks.Mediator")` so mediator Send metrics export with traces. Constant: `TelemetryDefaults.MediatorMeter`.

--- a/src/BuildingBlocks/Telemetry/BuildingBlocks.Telemetry.csproj
+++ b/src/BuildingBlocks/Telemetry/BuildingBlocks.Telemetry.csproj
@@ -16,19 +16,19 @@
     <IsPackable>true</IsPackable>
     <PackageId>BuildingBlocks.Telemetry</PackageId>
     <Title>BuildingBlocks.Telemetry</Title>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Mohammad Hasan Hosseini</Authors>
     <Company>Mohammad Hasan Hosseini</Company>
     <Copyright>Copyright (c) 2026 Mohammad Hasan Hosseini</Copyright>
     <Description>Config-driven OpenTelemetry metrics, logging, and tracing for .NET. Stable instrumentations (ASP.NET Core, HttpClient, Runtime, Npgsql, SqlClient) plus source-only MassTransit/EventBus/Mediator; OTLP, Console, and Azure Monitor exporters.</Description>
     <PackageTags>opentelemetry;telemetry;tracing;metrics;logging;otlp;applicationinsights;aspire;sqlclient;net8;net9;net10</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/Maxofpower/FeatureManagement</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Maxofpower/FeatureManagement</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/Maxofpower/FeatureFusion</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Maxofpower/FeatureFusion</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
     <PackageIcon>telemetry-icon.png</PackageIcon>
-    <PackageReleaseNotes>See CHANGELOG.md in the repository for release notes.</PackageReleaseNotes>
+    <PackageReleaseNotes>1.0.1: IntegrateMediator also AddMeter(BuildingBlocks.Mediator) so Send metrics export with traces; TelemetryDefaults.MediatorMeter. https://github.com/Maxofpower/FeatureFusion/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <None Include="PACKAGE_README.md" Pack="true" PackagePath="\" />
+    <None Include="AGENTS.md" Pack="true" PackagePath="\" />
     <None Include="telemetry-icon.png" Pack="true" PackagePath="\" />
     <None Include="PublicAPI.Shipped.txt" Pack="false" />
     <None Include="PublicAPI.Unshipped.txt" Pack="false" />

--- a/src/BuildingBlocks/Telemetry/Internal/Instrumentations/MetricsInstrumentations.cs
+++ b/src/BuildingBlocks/Telemetry/Internal/Instrumentations/MetricsInstrumentations.cs
@@ -42,6 +42,11 @@ internal static class MetricsInstrumentations
 
         SqlClientInstrumentation.ApplyMetricsIfEnabled(metrics, options);
 
+        if (options.IntegrateMediator)
+        {
+            metrics.AddMeter(TelemetryDefaults.MediatorMeter);
+        }
+
         foreach (var meter in options.Meters)
         {
             if (!string.IsNullOrWhiteSpace(meter))

--- a/src/BuildingBlocks/Telemetry/Options/TelemetryOptions.cs
+++ b/src/BuildingBlocks/Telemetry/Options/TelemetryOptions.cs
@@ -74,7 +74,8 @@ public sealed class TelemetryOptions
     public List<string> Meters { get; set; } = [];
 
     /// <summary>
-    /// When <c>true</c>, automatically adds the <see cref="TelemetryDefaults.MediatorActivitySource"/> source.
+    /// When <c>true</c>, automatically adds <see cref="TelemetryDefaults.MediatorActivitySource"/>
+    /// to tracing and <see cref="TelemetryDefaults.MediatorMeter"/> to metrics.
     /// Default: <c>true</c>.
     /// </summary>
     public bool IntegrateMediator { get; set; } = true;

--- a/src/BuildingBlocks/Telemetry/PACKAGE_README.md
+++ b/src/BuildingBlocks/Telemetry/PACKAGE_README.md
@@ -5,6 +5,11 @@ Config-driven OpenTelemetry metrics, logging, and tracing for .NET.
 [![NuGet](https://img.shields.io/nuget/v/BuildingBlocks.Telemetry.svg)](https://www.nuget.org/packages/BuildingBlocks.Telemetry)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+## What's new in 1.0.1
+
+- `IntegrateMediator` also `AddMeter("BuildingBlocks.Mediator")` so Send metrics export with traces
+- `TelemetryDefaults.MediatorMeter` (same name as the mediator ActivitySource)
+
 ## Requirements
 
 - **.NET 8**, **.NET 9**, or **.NET 10** (`net8.0` / `net9.0` / `net10.0`)
@@ -67,8 +72,8 @@ Endpoints, OTLP headers, and connection strings are never logged. Silence it wit
 
 ## Docs
 
-- [Telemetry guide](https://github.com/Maxofpower/FeatureManagement/blob/main/docs/building-blocks/telemetry.md)
-- [CHANGELOG](https://github.com/Maxofpower/FeatureManagement/blob/main/CHANGELOG.md)
+- [Telemetry guide](https://github.com/Maxofpower/FeatureFusion/blob/main/docs/building-blocks/telemetry.md)
+- [CHANGELOG](https://github.com/Maxofpower/FeatureFusion/blob/main/CHANGELOG.md)
 
 ## License
 

--- a/src/BuildingBlocks/Telemetry/PublicAPI.Shipped.txt
+++ b/src/BuildingBlocks/Telemetry/PublicAPI.Shipped.txt
@@ -87,6 +87,7 @@ namespace BuildingBlocks.Telemetry
     public static class TelemetryDefaults
     {
         public const string MediatorActivitySource = "BuildingBlocks.Mediator";
+        public const string MediatorMeter = "BuildingBlocks.Mediator";
         public const string MassTransitActivitySource = "MassTransit";
         public const string EventBusActivitySource = "EventBus";
     }

--- a/src/BuildingBlocks/Telemetry/PublicAPI.Unshipped.txt
+++ b/src/BuildingBlocks/Telemetry/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-# New public API for 1.0.0 — shipped at tag; keep empty for subsequent unshipped deltas.
+# New public API since 1.0.1 — move into PublicAPI.Shipped.txt when cutting the next version.

--- a/src/BuildingBlocks/Telemetry/TelemetryDefaults.cs
+++ b/src/BuildingBlocks/Telemetry/TelemetryDefaults.cs
@@ -18,6 +18,12 @@ public static class TelemetryDefaults
     public const string MediatorActivitySource = "BuildingBlocks.Mediator";
 
     /// <summary>
+    /// Meter name used by <c>BuildingBlocks.Mediator</c> when <c>UseTelemetry()</c> metrics are enabled.
+    /// Same value as <see cref="MediatorActivitySource"/> so one <c>IntegrateMediator</c> flag wires traces and metrics.
+    /// </summary>
+    public const string MediatorMeter = "BuildingBlocks.Mediator";
+
+    /// <summary>
     /// ActivitySource name used by MassTransit 8+ when <see cref="TelemetryInstrumentationOptions.MassTransit"/> is enabled.
     /// </summary>
     public const string MassTransitActivitySource = "MassTransit";

--- a/tests/BuildingBlocks/Aspire.Hosting.SigNoz.Tests/BuildingBlocks.Aspire.Hosting.SigNoz.Tests.csproj
+++ b/tests/BuildingBlocks/Aspire.Hosting.SigNoz.Tests/BuildingBlocks.Aspire.Hosting.SigNoz.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\BuildingBlocks.Aspire.Hosting.SigNoz\BuildingBlocks.Aspire.Hosting.SigNoz.csproj" />
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Aspire.Hosting.SigNoz\BuildingBlocks.Aspire.Hosting.SigNoz.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/BuildingBlocks/Mediator.Analyzers.Tests/BuildingBlocks.Mediator.Analyzers.Tests.csproj
+++ b/tests/BuildingBlocks/Mediator.Analyzers.Tests/BuildingBlocks.Mediator.Analyzers.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\BuildingBlocks.Mediator.Analyzers\BuildingBlocks.Mediator.Analyzers.csproj" />
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Mediator.Analyzers\BuildingBlocks.Mediator.Analyzers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/BuildingBlocks/Mediator.Tests/BuildingBlocks.Mediator.Tests.csproj
+++ b/tests/BuildingBlocks/Mediator.Tests/BuildingBlocks.Mediator.Tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\BuildingBlocks.Mediator\BuildingBlocks.Mediator.csproj" />
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Mediator\BuildingBlocks.Mediator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/BuildingBlocks/Mediator.Tests/PipelineBehaviorTests.cs
+++ b/tests/BuildingBlocks/Mediator.Tests/PipelineBehaviorTests.cs
@@ -1,4 +1,5 @@
 using BuildingBlocks.Mediator.DependencyInjection;
+using BuildingBlocks.Mediator.Pipeline;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -248,5 +249,321 @@ public sealed class PipelineBehaviorTests
 		await sp.GetRequiredService<ISender>().Send(new CancelOrder(Guid.NewGuid()));
 		Assert.Contains("open:CancelOrder", log);
 		Assert.True(state.VoidExecuted);
+	}
+
+	[Fact]
+	public async Task ConstrainedCommandBehavior_IsNotConstructedForQueries()
+	{
+		var counter = new ConstrainedBehaviorCounter();
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.AddOpenBehavior(typeof(ConstrainedCommandBehavior<,>));
+			},
+			s =>
+			{
+				s.AddSingleton(counter);
+				s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, CreateOrderHandler>();
+				s.AddTransient<IQueryHandler<GetOrder, OrderResult>, GetOrderHandler>();
+			});
+
+		var sender = sp.GetRequiredService<ISender>();
+		_ = await sender.Send(new GetOrder(Guid.NewGuid()));
+		Assert.Equal(0, counter.CommandConstructions);
+		Assert.DoesNotContain(counter.Log, x => x.StartsWith("constrained-cmd:"));
+
+		_ = await sender.Send(new CreateOrder("X", 1));
+		Assert.True(counter.CommandConstructions >= 1);
+		Assert.Contains("constrained-cmd:CreateOrder", counter.Log);
+	}
+
+	[Fact]
+	public async Task ConstrainedQueryBehavior_IsNotConstructedForCommands()
+	{
+		var counter = new ConstrainedBehaviorCounter();
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.AddOpenQueryBehavior(typeof(ConstrainedQueryBehavior<,>));
+			},
+			s =>
+			{
+				s.AddSingleton(counter);
+				s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, CreateOrderHandler>();
+				s.AddTransient<IQueryHandler<GetOrder, OrderResult>, GetOrderHandler>();
+			});
+
+		var sender = sp.GetRequiredService<ISender>();
+		_ = await sender.Send(new CreateOrder("X", 1));
+		Assert.Equal(0, counter.QueryConstructions);
+		Assert.DoesNotContain(counter.Log, x => x.StartsWith("constrained-query:"));
+
+		_ = await sender.Send(new GetOrder(Guid.NewGuid()));
+		Assert.True(counter.QueryConstructions >= 1);
+		Assert.Contains("constrained-query:GetOrder", counter.Log);
+	}
+
+	[Fact]
+	public async Task ConstrainedCommandBehavior_RunsOnVoidCommand()
+	{
+		var counter = new ConstrainedBehaviorCounter();
+		var state = new HandlerState();
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.AddOpenCommandBehavior(typeof(ConstrainedCommandBehavior<,>));
+			},
+			s =>
+			{
+				s.AddSingleton(counter);
+				s.AddSingleton(state);
+				s.AddTransient<ICommandHandler<CancelOrder>, CancelOrderHandler>();
+			});
+
+		await sp.GetRequiredService<ISender>().Send(new CancelOrder(Guid.NewGuid()));
+		Assert.True(counter.CommandConstructions >= 1);
+		Assert.Contains("constrained-cmd:CancelOrder", counter.Log);
+		Assert.True(state.VoidExecuted);
+	}
+
+	[Fact]
+	public async Task ConstrainedAndUnconstrainedBehaviors_SharePipelineOrder()
+	{
+		var log = new List<string>();
+		var counter = new ConstrainedBehaviorCounter();
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.AddOpenBehavior(typeof(OpenLoggingBehavior<,>), order: 0);
+				cfg.AddOpenCommandBehavior(typeof(ConstrainedCommandBehavior<,>), order: 10);
+			},
+			s =>
+			{
+				s.AddSingleton(log);
+				s.AddSingleton(counter);
+				s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, CreateOrderHandler>();
+			});
+
+		_ = await sp.GetRequiredService<ISender>().Send(new CreateOrder("X", 1));
+		Assert.Contains("open:CreateOrder", log);
+		Assert.Contains("constrained-cmd:CreateOrder", counter.Log);
+	}
+
+	[Fact]
+	public async Task ConstrainedCommandAndQueryBehaviors_IsolateByKind()
+	{
+		var counter = new ConstrainedBehaviorCounter();
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.AddOpenCommandBehavior(typeof(ConstrainedCommandBehavior<,>));
+				cfg.AddOpenQueryBehavior(typeof(ConstrainedQueryBehavior<,>));
+			},
+			s =>
+			{
+				s.AddSingleton(counter);
+				s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, CreateOrderHandler>();
+				s.AddTransient<IQueryHandler<GetOrder, OrderResult>, GetOrderHandler>();
+			});
+
+		var sender = sp.GetRequiredService<ISender>();
+
+		_ = await sender.Send(new CreateOrder("X", 1));
+		Assert.True(counter.CommandConstructions >= 1);
+		Assert.Equal(0, counter.QueryConstructions);
+		Assert.Contains("constrained-cmd:CreateOrder", counter.Log);
+		Assert.DoesNotContain(counter.Log, x => x.StartsWith("constrained-query:"));
+
+		_ = await sender.Send(new GetOrder(Guid.NewGuid()));
+		Assert.True(counter.QueryConstructions >= 1);
+		Assert.Contains("constrained-query:GetOrder", counter.Log);
+		Assert.DoesNotContain(counter.Log, x => x == "constrained-cmd:GetOrder");
+	}
+
+	[Fact]
+	public async Task ConstrainedBehaviors_RunOnOpenGenericMessages()
+	{
+		var counter = new ConstrainedBehaviorCounter();
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(OpenEchoHandler<>).Assembly);
+				cfg.AddOpenCommandBehavior(typeof(ConstrainedCommandBehavior<,>));
+				cfg.AddOpenQueryBehavior(typeof(ConstrainedQueryBehavior<,>));
+			},
+			s => s.AddSingleton(counter));
+
+		var sender = sp.GetRequiredService<ISender>();
+
+		Assert.Equal("hi", await sender.Send(new EchoCommand<string>("hi")));
+		Assert.True(counter.CommandConstructions >= 1);
+		Assert.Contains($"constrained-cmd:{typeof(EchoCommand<string>).Name}", counter.Log);
+
+		Assert.Equal(42, await sender.Send(new EchoQuery<int>(42)));
+		Assert.True(counter.QueryConstructions >= 1);
+		Assert.Contains($"constrained-query:{typeof(EchoQuery<int>).Name}", counter.Log);
+	}
+
+	[Fact]
+	public async Task ConstrainedBehaviors_RunOnResultAndNestedGenericResponse()
+	{
+		var counter = new ConstrainedBehaviorCounter();
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.AddOpenCommandBehavior(typeof(ConstrainedCommandBehavior<,>));
+				cfg.AddOpenQueryBehavior(typeof(ConstrainedQueryBehavior<,>));
+			},
+			s =>
+			{
+				s.AddSingleton(counter);
+				s.AddTransient<ICommandHandler<PlaceOrder, Result<Guid>>, PlaceOrderHandler>();
+				s.AddTransient<IQueryHandler<ListProducts, Result<PagedResult<string>>>, ListProductsHandler>();
+				s.AddTransient<IQueryHandler<ListIds, IReadOnlyList<int>>, ListIdsHandler>();
+			});
+
+		var sender = sp.GetRequiredService<ISender>();
+
+		var placed = await sender.Send(new PlaceOrder("SKU-1"));
+		Assert.True(placed.IsSuccess);
+		Assert.Contains("constrained-cmd:PlaceOrder", counter.Log);
+
+		var products = await sender.Send(new ListProducts(1));
+		Assert.True(products.IsSuccess);
+		Assert.Equal(2, products.Value!.Items.Count);
+		Assert.Contains("constrained-query:ListProducts", counter.Log);
+
+		Assert.Equal(new[] { 1, 2, 3 }, await sender.Send(new ListIds()));
+		Assert.Contains("constrained-query:ListIds", counter.Log);
+	}
+
+	[Fact]
+	public void AddOpenCommandBehavior_UnconstrainedPipelineType_Throws()
+	{
+		AssertRejectedOpenKind(
+			() => new MediatorConfiguration().AddOpenCommandBehavior(typeof(OpenLoggingBehavior<,>)),
+			typeof(OpenLoggingBehavior<,>),
+			"ICommandPipelineBehavior");
+	}
+
+	[Fact]
+	public void AddOpenQueryBehavior_UnconstrainedPipelineType_Throws()
+	{
+		AssertRejectedOpenKind(
+			() => new MediatorConfiguration().AddOpenQueryBehavior(typeof(OpenLoggingBehavior<,>)),
+			typeof(OpenLoggingBehavior<,>),
+			"IQueryPipelineBehavior");
+	}
+
+	[Fact]
+	public void AddOpenCommandBehavior_WrongKind_QueryBehavior_Throws()
+	{
+		AssertRejectedOpenKind(
+			() => new MediatorConfiguration().AddOpenCommandBehavior(typeof(ConstrainedQueryBehavior<,>)),
+			typeof(ConstrainedQueryBehavior<,>),
+			"ICommandPipelineBehavior",
+			mustNotContain: "IQueryPipelineBehavior");
+	}
+
+	[Fact]
+	public void AddOpenQueryBehavior_WrongKind_CommandBehavior_Throws()
+	{
+		AssertRejectedOpenKind(
+			() => new MediatorConfiguration().AddOpenQueryBehavior(typeof(ConstrainedCommandBehavior<,>)),
+			typeof(ConstrainedCommandBehavior<,>),
+			"IQueryPipelineBehavior",
+			mustNotContain: "ICommandPipelineBehavior");
+	}
+
+	[Fact]
+	public void AddOpenCommandBehavior_LegacyRuntimeSkipBase_Throws()
+	{
+		AssertRejectedOpenKind(
+			() => new MediatorConfiguration().AddOpenCommandBehavior(typeof(CommandPipelineBehavior<,>)),
+			typeof(CommandPipelineBehavior<,>),
+			"ICommandPipelineBehavior");
+	}
+
+	[Fact]
+	public void AddOpenQueryBehavior_LegacyRuntimeSkipBase_Throws()
+	{
+		AssertRejectedOpenKind(
+			() => new MediatorConfiguration().AddOpenQueryBehavior(typeof(QueryPipelineBehavior<,>)),
+			typeof(QueryPipelineBehavior<,>),
+			"IQueryPipelineBehavior");
+	}
+
+	[Fact]
+	public void AddOpenCommandBehavior_NonPipelineOpenGeneric_Throws()
+	{
+		AssertRejectedOpenKind(
+			() => new MediatorConfiguration().AddOpenCommandBehavior(typeof(List<>)),
+			typeof(List<>),
+			"ICommandPipelineBehavior");
+	}
+
+	[Fact]
+	public void AddOpenQueryBehavior_NonPipelineOpenGeneric_Throws()
+	{
+		AssertRejectedOpenKind(
+			() => new MediatorConfiguration().AddOpenQueryBehavior(typeof(List<>)),
+			typeof(List<>),
+			"IQueryPipelineBehavior");
+	}
+
+	[Fact]
+	public void AddOpenCommandBehavior_NonOpenGeneric_Throws()
+	{
+		var ex = Assert.Throws<ArgumentException>(
+			() => new MediatorConfiguration().AddOpenCommandBehavior(typeof(RecordingBehavior)));
+		Assert.Equal("openBehaviorType", ex.ParamName);
+		Assert.Contains(nameof(RecordingBehavior), ex.Message, StringComparison.Ordinal);
+		Assert.Contains("open generic type definition", ex.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void AddOpenQueryBehavior_NonOpenGeneric_Throws()
+	{
+		var ex = Assert.Throws<ArgumentException>(
+			() => new MediatorConfiguration().AddOpenQueryBehavior(typeof(RecordingBehavior)));
+		Assert.Equal("openBehaviorType", ex.ParamName);
+		Assert.Contains(nameof(RecordingBehavior), ex.Message, StringComparison.Ordinal);
+		Assert.Contains("open generic type definition", ex.Message, StringComparison.Ordinal);
+	}
+
+	[Fact]
+	public void AddOpenCommandBehavior_Null_Throws()
+	{
+		var ex = Assert.Throws<ArgumentNullException>(
+			() => new MediatorConfiguration().AddOpenCommandBehavior(null!));
+		Assert.Equal("openBehaviorType", ex.ParamName);
+	}
+
+	[Fact]
+	public void AddOpenQueryBehavior_Null_Throws()
+	{
+		var ex = Assert.Throws<ArgumentNullException>(
+			() => new MediatorConfiguration().AddOpenQueryBehavior(null!));
+		Assert.Equal("openBehaviorType", ex.ParamName);
+	}
+
+	private static void AssertRejectedOpenKind(
+		Action register,
+		Type wrongType,
+		string requiredInterface,
+		string? mustNotContain = null)
+	{
+		var ex = Assert.Throws<ArgumentException>(register);
+		Assert.Equal("openBehaviorType", ex.ParamName);
+		Assert.Contains(wrongType.Name, ex.Message, StringComparison.Ordinal);
+		Assert.Contains($"must implement {requiredInterface}", ex.Message, StringComparison.Ordinal);
+		if (mustNotContain is not null)
+			Assert.DoesNotContain(mustNotContain, ex.Message, StringComparison.Ordinal);
 	}
 }

--- a/tests/BuildingBlocks/Mediator.Tests/TelemetryRegistrationTests.cs
+++ b/tests/BuildingBlocks/Mediator.Tests/TelemetryRegistrationTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using BuildingBlocks.Mediator.DependencyInjection;
 using BuildingBlocks.Mediator.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
@@ -246,6 +247,111 @@ public sealed class TelemetryRegistrationTests
 		Assert.Contains("ActivitySourceName", ex.Message, StringComparison.Ordinal);
 	}
 
+	[Fact]
+	public async Task UseTelemetry_OnSuccess_RecordsDurationAndSendCounter()
+	{
+		using var metrics = new MetricSink("BuildingBlocks.Mediator.Tests");
+
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.UseTelemetry(o => o.ActivitySourceName = "BuildingBlocks.Mediator.Tests");
+			},
+			s => s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, CreateOrderHandler>());
+
+		_ = await sp.GetRequiredService<ISender>().Send(new CreateOrder("A", 1));
+
+		var duration = Assert.Single(metrics.Doubles, d => d.Instrument == "mediator.send.duration");
+		Assert.True(duration.Value >= 0);
+		Assert.Equal("command", duration.Tags["mediator.message_kind"]);
+		Assert.Equal("CreateOrder", duration.Tags["mediator.request_name"]);
+
+		var count = Assert.Single(metrics.Longs, d => d.Instrument == "mediator.send");
+		Assert.Equal(1L, count.Value);
+		Assert.Equal(true, count.Tags["mediator.success"]);
+		Assert.Equal("command", count.Tags["mediator.message_kind"]);
+	}
+
+	[Fact]
+	public async Task UseTelemetry_OnFault_RecordsFailedSendCounter_AndRethrows()
+	{
+		using var metrics = new MetricSink("BuildingBlocks.Mediator.Tests");
+
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.UseTelemetry(o => o.ActivitySourceName = "BuildingBlocks.Mediator.Tests");
+			},
+			s => s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, ThrowingCreateOrderHandler>());
+
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => sp.GetRequiredService<ISender>().Send(new CreateOrder("A", 1)));
+
+		var count = Assert.Single(metrics.Longs, d => d.Instrument == "mediator.send");
+		Assert.Equal(1L, count.Value);
+		Assert.Equal(false, count.Tags["mediator.success"]);
+		Assert.Single(metrics.Doubles, d => d.Instrument == "mediator.send.duration");
+	}
+
+	[Fact]
+	public async Task UseTelemetry_EnableMetricsFalse_DoesNotRecord()
+	{
+		using var metrics = new MetricSink("BuildingBlocks.Mediator.Tests");
+
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.UseTelemetry(o =>
+				{
+					o.ActivitySourceName = "BuildingBlocks.Mediator.Tests";
+					o.EnableMetrics = false;
+				});
+			},
+			s => s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, CreateOrderHandler>());
+
+		_ = await sp.GetRequiredService<ISender>().Send(new CreateOrder("A", 1));
+		Assert.Empty(metrics.Doubles);
+		Assert.Empty(metrics.Longs);
+	}
+
+	[Fact]
+	public async Task UseTelemetry_Omitted_DoesNotRecordMetrics()
+	{
+		using var metrics = new MetricSink("BuildingBlocks.Mediator.Tests");
+
+		await using var sp = TestHost.Build(s =>
+			s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, CreateOrderHandler>());
+
+		_ = await sp.GetRequiredService<ISender>().Send(new CreateOrder("A", 1));
+		Assert.Empty(metrics.Doubles);
+		Assert.Empty(metrics.Longs);
+	}
+
+	[Fact]
+	public async Task UseTelemetry_CustomMeterName_IsHonored()
+	{
+		const string meterName = "BuildingBlocks.Mediator.CustomMeter";
+		using var metrics = new MetricSink(meterName);
+
+		using var sp = TestHost.BuildWithAddMediator(
+			cfg =>
+			{
+				cfg.RegisterServicesFromAssembly(typeof(AssemblyMarker).Assembly);
+				cfg.UseTelemetry(o =>
+				{
+					o.ActivitySourceName = "BuildingBlocks.Mediator.Tests";
+					o.MeterName = meterName;
+				});
+			},
+			s => s.AddTransient<ICommandHandler<CreateOrder, OrderResult>, CreateOrderHandler>());
+
+		_ = await sp.GetRequiredService<ISender>().Send(new CreateOrder("A", 1));
+		Assert.Single(metrics.Longs, d => d.Instrument == "mediator.send");
+	}
+
 	private static ActivityListener CreateListener(List<Activity> sink, string sourceName = "BuildingBlocks.Mediator.Tests")
 	{
 		var listener = new ActivityListener
@@ -256,5 +362,39 @@ public sealed class TelemetryRegistrationTests
 		};
 		ActivitySource.AddActivityListener(listener);
 		return listener;
+	}
+
+	private sealed class MetricSink : IDisposable
+	{
+		private readonly MeterListener _listener;
+
+		public List<(string Instrument, double Value, Dictionary<string, object?> Tags)> Doubles { get; } = new();
+
+		public List<(string Instrument, long Value, Dictionary<string, object?> Tags)> Longs { get; } = new();
+
+		public MetricSink(string meterName)
+		{
+			_listener = new MeterListener();
+			_listener.InstrumentPublished = (instrument, listener) =>
+			{
+				if (instrument.Meter.Name == meterName)
+					listener.EnableMeasurementEvents(instrument);
+			};
+			_listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+				Doubles.Add((instrument.Name, value, ToDictionary(tags))));
+			_listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+				Longs.Add((instrument.Name, value, ToDictionary(tags))));
+			_listener.Start();
+		}
+
+		public void Dispose() => _listener.Dispose();
+
+		private static Dictionary<string, object?> ToDictionary(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+		{
+			var map = new Dictionary<string, object?>(StringComparer.Ordinal);
+			foreach (var tag in tags)
+				map[tag.Key] = tag.Value;
+			return map;
+		}
 	}
 }

--- a/tests/BuildingBlocks/Mediator.Tests/TestFixtures.cs
+++ b/tests/BuildingBlocks/Mediator.Tests/TestFixtures.cs
@@ -500,3 +500,52 @@ public sealed class NotifyOrderCreatedHandler : ICommandHandler<NotifyOrderCreat
 		return Task.CompletedTask;
 	}
 }
+
+public sealed class ConstrainedBehaviorCounter
+{
+	public int CommandConstructions;
+	public int QueryConstructions;
+	public readonly List<string> Log = new();
+}
+
+public sealed class ConstrainedCommandBehavior<TCommand, TResponse> : Pipeline.ICommandPipelineBehavior<TCommand, TResponse>
+	where TCommand : ICommand<TResponse>
+{
+	private readonly ConstrainedBehaviorCounter _counter;
+
+	public ConstrainedCommandBehavior(ConstrainedBehaviorCounter counter)
+	{
+		_counter = counter;
+		Interlocked.Increment(ref _counter.CommandConstructions);
+	}
+
+	public Task<TResponse> Handle(
+		TCommand request,
+		RequestHandlerDelegate<TResponse> next,
+		CancellationToken cancellationToken = default)
+	{
+		_counter.Log.Add($"constrained-cmd:{typeof(TCommand).Name}");
+		return next(cancellationToken);
+	}
+}
+
+public sealed class ConstrainedQueryBehavior<TQuery, TResponse> : Pipeline.IQueryPipelineBehavior<TQuery, TResponse>
+	where TQuery : IQuery<TResponse>
+{
+	private readonly ConstrainedBehaviorCounter _counter;
+
+	public ConstrainedQueryBehavior(ConstrainedBehaviorCounter counter)
+	{
+		_counter = counter;
+		Interlocked.Increment(ref _counter.QueryConstructions);
+	}
+
+	public Task<TResponse> Handle(
+		TQuery request,
+		RequestHandlerDelegate<TResponse> next,
+		CancellationToken cancellationToken = default)
+	{
+		_counter.Log.Add($"constrained-query:{typeof(TQuery).Name}");
+		return next(cancellationToken);
+	}
+}

--- a/tests/BuildingBlocks/Telemetry.Tests/AddTelemetry/AddTelemetryRegistrationTests.cs
+++ b/tests/BuildingBlocks/Telemetry.Tests/AddTelemetry/AddTelemetryRegistrationTests.cs
@@ -60,6 +60,8 @@ public sealed class AddTelemetryRegistrationTests
     public void Mediator_activity_source_name_matches_defaults()
     {
         Assert.Equal("BuildingBlocks.Mediator", TelemetryDefaults.MediatorActivitySource);
+        Assert.Equal("BuildingBlocks.Mediator", TelemetryDefaults.MediatorMeter);
+        Assert.Equal(TelemetryDefaults.MediatorActivitySource, TelemetryDefaults.MediatorMeter);
         Assert.Equal("MassTransit", TelemetryDefaults.MassTransitActivitySource);
         Assert.Equal("EventBus", TelemetryDefaults.EventBusActivitySource);
     }

--- a/tests/BuildingBlocks/Telemetry.Tests/BuildingBlocks.Telemetry.Tests.csproj
+++ b/tests/BuildingBlocks/Telemetry.Tests/BuildingBlocks.Telemetry.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\BuildingBlocks.Telemetry\BuildingBlocks.Telemetry.csproj" />
+    <ProjectReference Include="..\..\..\src\BuildingBlocks\Telemetry\BuildingBlocks.Telemetry.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Ship BuildingBlocks.Mediator 1.1.0 with ICommandPipelineBehavior, IQueryPipelineBehavior, and opt-in mediator.send metrics. BuildingBlocks.Telemetry 1.0.1 IntegrateMediator also AddMeter so those metrics export.